### PR TITLE
fix(server): return 400 for malformed `/api/chat` JSON requests

### DIFF
--- a/apps/server/src/routes/chat-errors.test.ts
+++ b/apps/server/src/routes/chat-errors.test.ts
@@ -76,6 +76,18 @@ describe('Chat Route - Error Handling', () => {
     db.close();
   });
 
+  test('returns 400 when request body is malformed JSON', async () => {
+    const res = await testApp.request('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{"messages":[{"role":"user","content":"hello"}', // missing closing braces
+    });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe('Malformed JSON request body');
+  });
+
   test('sends error StreamEvent when Claude API throws rate limit error', async () => {
     mockQuery.mockImplementation(() =>
       (async function* () {

--- a/apps/server/src/routes/chat.ts
+++ b/apps/server/src/routes/chat.ts
@@ -279,7 +279,12 @@ export function createChatRouter(db: Database) {
 
   router.post('/', async (c) => {
     console.log('[chat] === NEW CHAT REQUEST ===');
-    const bodyRaw = await c.req.json();
+    let bodyRaw: unknown;
+    try {
+      bodyRaw = await c.req.json();
+    } catch {
+      return c.json({ error: 'Malformed JSON request body' }, 400);
+    }
     const parsed = chatRequestSchema.safeParse(bodyRaw);
     if (!parsed.success) {
       return c.json(

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -161,3 +161,9 @@ Each entry follows this format:
 **Type**: Technical Decision
 **Impact**: High
 **Description**: Established project documentation structure, TDD policy, worktree workflow, and agent conventions. Set up comprehensive docs/ folder with indexes, logging system, and runbooks.
+
+## 2026-03-18
+### Chat route malformed JSON handling regression fix
+- **What:** Added a regression test for `POST /api/chat` malformed JSON input and updated the chat route to catch `c.req.json()` parse errors, returning HTTP 400 with `{ "error": "Malformed JSON request body" }` instead of surfacing a 500.
+- **Why:** Manual API investigation documented that invalid JSON was returning 500, which treats client input errors as server faults and makes error handling noisy.
+- **Result:** Targeted server tests pass, and manual curl verification now returns 400 for malformed JSON bodies.


### PR DESCRIPTION
### Motivation
- Malformed JSON bodies sent to `POST /api/chat` were surfacing as 500 server errors instead of client errors, creating noisy logs and incorrect status codes. 
- Add regression coverage to prevent regressions and ensure the route validates input robustness.

### Description
- Wrap `c.req.json()` in a `try/catch` inside `createChatRouter` and return `400` with `{ "error": "Malformed JSON request body" }` when parsing fails (`apps/server/src/routes/chat.ts`).
- Add a focused regression test `returns 400 when request body is malformed JSON` to `apps/server/src/routes/chat-errors.test.ts` to assert the new behavior.
- Record the fix and validation outcome in `docs/logs/engineering-log.md` per project documentation policy.

### Testing
- Ran `cd apps/server && bun test src/routes/chat-errors.test.ts` and the new test passed.
- Ran `cd apps/server && bun test src/routes/chat.test.ts` and the file-level suite passed.
- All automated tests executed for the modified areas succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baf8e84de083238fee2f82bf29db13)