### PR TITLE
fix(server): handle default branch detection across git init defaults

### DIFF
--- a/apps/server/src/routes/workspaces-diff.test.ts
+++ b/apps/server/src/routes/workspaces-diff.test.ts
@@ -14,6 +14,7 @@ let repoPath: string;
 let db: Database;
 let app: Hono;
 let projectId: string;
+let defaultBranch: string;
 
 beforeAll(async () => {
   // Create a real temp git repo
@@ -33,6 +34,11 @@ beforeAll(async () => {
   await Bun.write(initFile, '# Test');
   Bun.spawnSync(['git', 'add', '.'], { cwd: repoPath });
   Bun.spawnSync(['git', 'commit', '-m', 'initial'], { cwd: repoPath });
+
+  const branchResult = Bun.spawnSync(['git', 'symbolic-ref', '--short', 'HEAD'], {
+    cwd: repoPath,
+  });
+  defaultBranch = branchResult.stdout.toString().trim() || 'main';
 });
 
 afterAll(() => {
@@ -54,7 +60,7 @@ beforeEach(() => {
     'test-project',
     repoPath,
     realpath || repoPath,
-    'main'
+    defaultBranch
   );
   projectId = project.id;
 

--- a/apps/server/src/services/git-command.test.ts
+++ b/apps/server/src/services/git-command.test.ts
@@ -86,4 +86,18 @@ describe('GitCommandRunner.getDefaultBranch', () => {
     // git init creates main or master depending on config
     expect(['main', 'master']).toContain(branch);
   });
+
+  test('returns HEAD branch for an unborn repository', async () => {
+    const unbornRepoDir = join(tempDir, 'unborn-repo');
+    await Bun.spawn(['mkdir', '-p', unbornRepoDir]).exited;
+    await Bun.spawn(['git', 'init'], { cwd: unbornRepoDir }).exited;
+
+    const head = await git.run(['symbolic-ref', '--short', 'HEAD'], {
+      cwd: unbornRepoDir,
+    });
+    expect(head.exitCode).toBe(0);
+
+    const branch = await git.getDefaultBranch(unbornRepoDir);
+    expect(branch).toBe(head.stdout.trim());
+  });
 });

--- a/apps/server/src/services/git-command.ts
+++ b/apps/server/src/services/git-command.ts
@@ -104,6 +104,14 @@ export class GitCommandRunner {
       if (branch) return branch;
     }
 
+    // Fallback: current HEAD symbolic ref (works for unborn repos too)
+    const headRefResult = await this.run(['symbolic-ref', '--short', 'HEAD'], {
+      cwd: repoPath,
+    });
+    if (headRefResult.exitCode === 0 && headRefResult.stdout.trim()) {
+      return headRefResult.stdout.trim();
+    }
+
     // Fallback: check if 'main' branch exists
     const mainResult = await this.run(['rev-parse', '--verify', 'refs/heads/main'], {
       cwd: repoPath,


### PR DESCRIPTION
### Motivation

- Tests and workspace creation were brittle when repositories initialized with `master` or had an unborn HEAD, causing `fatal: invalid reference: main` during worktree creation.

### Description

- Prefer `git symbolic-ref --short HEAD` when `origin/HEAD` is unavailable to detect the repository default branch, which also works for unborn/local-only repos, implemented in `apps/server/src/services/git-command.ts`.
- Added a regression test proving `getDefaultBranch()` returns the current `HEAD` for an unborn repo in `apps/server/src/services/git-command.test.ts`.
- Made the workspace diff/merge/discard tests branch-agnostic by deriving the initialized repo branch instead of hard-coding `main` in `apps/server/src/routes/workspaces-diff.test.ts`.
- Files changed: `apps/server/src/services/git-command.ts`, `apps/server/src/services/git-command.test.ts`, `apps/server/src/routes/workspaces-diff.test.ts`.

### Testing

- Ran the focused unit test `cd apps/server && bun test src/services/git-command.test.ts` which passed. 
- Ran the workspace tests `cd apps/server && bun test src/routes/workspaces-diff.test.ts` which passed. 
- Ran the full server test suite via `pnpm test` and observed the server tests complete green. 
- Ran a desktop unit test `cd apps/desktop && pnpm vitest run src/hooks/useSettings.test.ts` which passed, and performed manual API verification by launching the server (`pnpm --filter @claude-tauri/server dev`) and using `curl` to create a temp repo, `POST /api/projects`, and `POST /api/projects/:id/workspaces` to confirm a workspace is created with `status: "ready"` and the correct `baseBranch`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baf8ac864883239473f2c5f8299581)