### PR TITLE
feat(#82): multiple chat tabs per session

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -6,6 +6,7 @@ import { AuthGate } from '@/components/auth/AuthGate';
 import { SessionSidebar } from '@/components/sessions/SessionSidebar';
 import { ChatPage } from '@/components/chat/ChatPage';
 import { WelcomeScreen } from '@/components/chat/WelcomeScreen';
+import { ChatTabsBar } from '@/components/chat/ChatTabsBar';
 import type { ChatPageStatusData } from '@/components/chat/ChatPage';
 import { SettingsPanel } from '@/components/settings/SettingsPanel';
 import { TeamsView } from '@/components/teams/TeamsView';
@@ -69,15 +70,45 @@ function AppLayout({ email, plan }: { email?: string; plan?: string }) {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [settingsInitialTab, setSettingsInitialTab] = useState<string | undefined>();
   const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [openSessionIds, setOpenSessionIds] = useState<string[]>([]);
 
   const handleOpenSettings = useCallback((tab?: string) => {
     setSettingsInitialTab(tab);
     setSettingsOpen(true);
   }, []);
 
+  const [statusData, setStatusData] = useState<StatusBarProps & { sessionInfo?: ChatPageStatusData['sessionInfo'] }>(defaultStatusData);
+  const [activeView, setActiveView] = useState<'chat' | 'teams' | 'workspaces' | 'agents'>('chat');
+  const [activeSessionHasMessages, setActiveSessionHasMessages] = useState(false);
+
   // Global keyboard shortcuts (work from any view)
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 't') {
+        if (activeView !== 'chat') return;
+        e.preventDefault();
+        void createSession();
+        setActiveSessionHasMessages(false);
+        return;
+      }
+
+      if (e.ctrlKey && e.key === 'Tab') {
+        if (activeView !== 'chat') return;
+        if (openSessionIds.length < 2) return;
+        e.preventDefault();
+        const currentIndex = activeSessionId
+          ? openSessionIds.indexOf(activeSessionId)
+          : -1;
+        const nextIndex = e.shiftKey
+          ? (currentIndex - 1 + openSessionIds.length) % openSessionIds.length
+          : (currentIndex + 1) % openSessionIds.length;
+        const nextId = openSessionIds[nextIndex];
+        if (nextId) {
+          setActiveSessionId(nextId);
+        }
+        return;
+      }
+
       if (e.key === ',' && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
         handleOpenSettings();
@@ -85,10 +116,7 @@ function AppLayout({ email, plan }: { email?: string; plan?: string }) {
     };
     document.addEventListener('keydown', handler);
     return () => document.removeEventListener('keydown', handler);
-  }, [handleOpenSettings]);
-  const [statusData, setStatusData] = useState<StatusBarProps & { sessionInfo?: ChatPageStatusData['sessionInfo'] }>(defaultStatusData);
-  const [activeView, setActiveView] = useState<'chat' | 'teams' | 'workspaces' | 'agents'>('chat');
-  const [activeSessionHasMessages, setActiveSessionHasMessages] = useState(false);
+  }, [handleOpenSettings, activeView, openSessionIds, activeSessionId, setActiveSessionId, createSession]);
   const selectedSessionHasMessages = (session?: (typeof sessions)[number]) => {
     if (!session) return false;
     return session.claudeSessionId != null || (session.messageCount ?? 0) > 0;
@@ -263,6 +291,45 @@ function AppLayout({ email, plan }: { email?: string; plan?: string }) {
     setActiveView('teams');
   }, []);
 
+  // Keep the active session in the open tab list.
+  useEffect(() => {
+    if (!activeSessionId) return;
+    setOpenSessionIds((prev) =>
+      prev.includes(activeSessionId) ? prev : [...prev, activeSessionId]
+    );
+  }, [activeSessionId]);
+
+  // If a session is deleted, drop it from open tabs.
+  useEffect(() => {
+    setOpenSessionIds((prev) =>
+      prev.filter((id) => sessions.some((s) => s.id === id))
+    );
+  }, [sessions]);
+
+  const handleActivateTab = useCallback(
+    (id: string) => {
+      setActiveView('chat');
+      setActiveSessionId(id);
+      const session = sessions.find((s) => s.id === id);
+      setActiveSessionHasMessages(selectedSessionHasMessages(session));
+    },
+    [setActiveSessionId, sessions]
+  );
+
+  const handleCloseTab = useCallback(
+    (id: string) => {
+      setOpenSessionIds((prev) => {
+        const next = prev.filter((x) => x !== id);
+        if (id === activeSessionId) {
+          const nextActive = next[next.length - 1] ?? null;
+          setActiveSessionId(nextActive);
+        }
+        return next;
+      });
+    },
+    [activeSessionId, setActiveSessionId]
+  );
+
   const handleDeleteProject = useCallback(async (projectId: string) => {
     await removeProject(projectId);
     if (selectedProjectId === projectId) {
@@ -342,30 +409,44 @@ function AppLayout({ email, plan }: { email?: string; plan?: string }) {
           />
         )}
         {activeView === 'chat' ? (
-          activeSessionId ? (
-            <ChatPage
-              sessionId={activeSessionId}
-              onCreateSession={handleNewChat}
-              onExportSession={() => exportSession(activeSessionId, 'json')}
-              onStatusChange={handleStatusChange}
-              onAutoName={autoNameSession}
-              onToggleSidebar={() => setSidebarOpen((open) => !open)}
-              onOpenSettings={handleOpenSettings}
-              onOpenSessions={handleOpenSessions}
-              onOpenPullRequests={handleOpenPullRequests}
-              onTaskComplete={(params) => handleTaskComplete(params)}
-              profileId={selectedProfileId}
-              agentProfiles={agentProfiles}
-              onSelectProfile={setSelectedProfileId}
-            />
-          ) : (
-            <WelcomeScreen
-              onNewChat={handleNewChat}
-              agentProfiles={agentProfiles}
-              selectedProfileId={selectedProfileId}
-              onSelectProfile={setSelectedProfileId}
-            />
-          )
+          <div className="flex flex-1 flex-col min-w-0 min-h-0">
+            {openSessionIds.length > 0 && (
+              <ChatTabsBar
+                sessions={sessions}
+                openSessionIds={openSessionIds}
+                activeSessionId={activeSessionId}
+                onActivate={handleActivateTab}
+                onClose={handleCloseTab}
+                onRename={renameSession}
+                onNewTab={handleNewChat}
+              />
+            )}
+
+            {activeSessionId ? (
+              <ChatPage
+                sessionId={activeSessionId}
+                onCreateSession={handleNewChat}
+                onExportSession={() => exportSession(activeSessionId, 'json')}
+                onStatusChange={handleStatusChange}
+                onAutoName={autoNameSession}
+                onToggleSidebar={() => setSidebarOpen((open) => !open)}
+                onOpenSettings={handleOpenSettings}
+                onOpenSessions={handleOpenSessions}
+                onOpenPullRequests={handleOpenPullRequests}
+                onTaskComplete={(params) => handleTaskComplete(params)}
+                profileId={selectedProfileId}
+                agentProfiles={agentProfiles}
+                onSelectProfile={setSelectedProfileId}
+              />
+            ) : (
+              <WelcomeScreen
+                onNewChat={handleNewChat}
+                agentProfiles={agentProfiles}
+                selectedProfileId={selectedProfileId}
+                onSelectProfile={setSelectedProfileId}
+              />
+            )}
+          </div>
         ) : activeView === 'workspaces' ? (
           selectedWorkspace ? (
             <WorkspacePanel

--- a/apps/desktop/src/components/chat/ChatTabsBar.tsx
+++ b/apps/desktop/src/components/chat/ChatTabsBar.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { Session } from '@claude-tauri/shared';
+import { X } from '@phosphor-icons/react';
+
+interface ChatTabsBarProps {
+  sessions: Session[];
+  openSessionIds: string[];
+  activeSessionId: string | null;
+  onActivate: (sessionId: string) => void;
+  onClose: (sessionId: string) => void;
+  onRename: (sessionId: string, title: string) => void;
+  onNewTab: () => void;
+}
+
+function titleForSession(sessions: Session[], sessionId: string): string {
+  const session = sessions.find((s) => s.id === sessionId);
+  return session?.title?.trim() || 'New Chat';
+}
+
+export function ChatTabsBar({
+  sessions,
+  openSessionIds,
+  activeSessionId,
+  onActivate,
+  onClose,
+  onRename,
+  onNewTab,
+}: ChatTabsBarProps) {
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState('');
+  const renameInputRef = useRef<HTMLInputElement>(null);
+
+  const orderedOpenIds = useMemo(
+    () => openSessionIds.filter((id) => sessions.some((s) => s.id === id)),
+    [openSessionIds, sessions]
+  );
+
+  useEffect(() => {
+    if (!renamingId) return;
+    renameInputRef.current?.focus();
+    renameInputRef.current?.select();
+  }, [renamingId]);
+
+  const submitRename = (id: string) => {
+    const trimmed = renameValue.trim();
+    if (trimmed) {
+      onRename(id, trimmed);
+    }
+    setRenamingId(null);
+    setRenameValue('');
+  };
+
+  return (
+    <div
+      className="flex items-center gap-1 border-b border-border bg-sidebar px-2 py-1"
+      data-testid="chat-tabs-bar"
+    >
+      <button
+        type="button"
+        onClick={onNewTab}
+        className="mr-1 inline-flex h-7 items-center rounded-md border border-border bg-background px-2 text-xs font-medium text-muted-foreground transition hover:bg-muted/50 hover:text-foreground"
+        data-testid="chat-tab-new"
+        aria-label="New chat tab"
+      >
+        New Tab
+      </button>
+
+      <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto">
+        {orderedOpenIds.map((id) => {
+          const title = titleForSession(sessions, id);
+          const isActive = id === activeSessionId;
+
+          return (
+            <div
+              key={id}
+              className={`group inline-flex items-center gap-2 rounded-md border px-2 py-1 text-xs transition ${
+                isActive
+                  ? 'border-primary bg-background text-foreground'
+                  : 'border-border bg-background/30 text-muted-foreground hover:bg-muted/40 hover:text-foreground'
+              }`}
+            >
+              <button
+                type="button"
+                data-testid={`chat-tab-${id}`}
+                onClick={() => onActivate(id)}
+                onDoubleClick={() => {
+                  setRenamingId(id);
+                  setRenameValue(title);
+                }}
+                onMouseDown={(e) => {
+                  // Middle click closes
+                  if (e.button === 1) {
+                    e.preventDefault();
+                    onClose(id);
+                  }
+                }}
+                className="min-w-0 max-w-[180px] truncate text-left"
+                aria-current={isActive ? 'page' : undefined}
+              >
+                {renamingId === id ? (
+                  <input
+                    ref={renameInputRef}
+                    value={renameValue}
+                    onChange={(e) => setRenameValue(e.target.value)}
+                    onClick={(e) => e.stopPropagation()}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault();
+                        submitRename(id);
+                      } else if (e.key === 'Escape') {
+                        e.preventDefault();
+                        setRenamingId(null);
+                        setRenameValue('');
+                      }
+                    }}
+                    onBlur={() => submitRename(id)}
+                    data-testid={`chat-tab-rename-input-${id}`}
+                    className="h-5 w-[140px] rounded border border-border bg-background px-1 text-xs text-foreground outline-none focus:ring-1 focus:ring-ring"
+                  />
+                ) : (
+                  title
+                )}
+              </button>
+
+              <button
+                type="button"
+                onClick={() => onClose(id)}
+                data-testid={`chat-tab-close-${id}`}
+                aria-label="Close tab"
+                className="inline-flex h-5 w-5 items-center justify-center rounded text-muted-foreground opacity-60 transition hover:bg-muted/60 hover:text-foreground group-hover:opacity-100"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/chat/__tests__/ChatTabsBar.test.tsx
+++ b/apps/desktop/src/components/chat/__tests__/ChatTabsBar.test.tsx
@@ -1,0 +1,86 @@
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { Session } from '@claude-tauri/shared';
+import { ChatTabsBar } from '../ChatTabsBar';
+
+const sessions: Session[] = [
+  {
+    id: 's-1',
+    title: 'First Chat',
+    createdAt: '2026-03-14T10:00:00.000Z',
+    updatedAt: '2026-03-14T10:00:00.000Z',
+  },
+  {
+    id: 's-2',
+    title: 'Second Chat',
+    createdAt: '2026-03-14T11:00:00.000Z',
+    updatedAt: '2026-03-14T11:00:00.000Z',
+  },
+];
+
+describe('ChatTabsBar', () => {
+  it('renders tabs and activates them when clicked', () => {
+    const onActivate = vi.fn();
+
+    render(
+      <ChatTabsBar
+        sessions={sessions}
+        openSessionIds={['s-1', 's-2']}
+        activeSessionId="s-1"
+        onActivate={onActivate}
+        onClose={vi.fn()}
+        onRename={vi.fn()}
+        onNewTab={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('chat-tab-s-1')).toHaveTextContent('First Chat');
+    expect(screen.getByTestId('chat-tab-s-2')).toHaveTextContent('Second Chat');
+
+    fireEvent.click(screen.getByTestId('chat-tab-s-2'));
+    expect(onActivate).toHaveBeenCalledWith('s-2');
+  });
+
+  it('calls onClose when the close button is clicked', () => {
+    const onClose = vi.fn();
+
+    render(
+      <ChatTabsBar
+        sessions={sessions}
+        openSessionIds={['s-1', 's-2']}
+        activeSessionId="s-1"
+        onActivate={vi.fn()}
+        onClose={onClose}
+        onRename={vi.fn()}
+        onNewTab={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('chat-tab-close-s-2'));
+    expect(onClose).toHaveBeenCalledWith('s-2');
+  });
+
+  it('enters rename mode on double click and submits rename on Enter', () => {
+    const onRename = vi.fn();
+
+    render(
+      <ChatTabsBar
+        sessions={sessions}
+        openSessionIds={['s-1']}
+        activeSessionId="s-1"
+        onActivate={vi.fn()}
+        onClose={vi.fn()}
+        onRename={onRename}
+        onNewTab={vi.fn()}
+      />
+    );
+
+    fireEvent.doubleClick(screen.getByTestId('chat-tab-s-1'));
+    const input = screen.getByTestId('chat-tab-rename-input-s-1') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Renamed' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onRename).toHaveBeenCalledWith('s-1', 'Renamed');
+  });
+});


### PR DESCRIPTION
## Summary
- Cmd+T opens a new chat tab (independent session)
- Tab bar with inline rename (double-click tab title)
- Close tabs individually (× button or middle-click awareness)
- Ctrl+Tab / Shift+Ctrl+Tab to cycle through open tabs
- Active session automatically added to tab list; deleted sessions auto-removed

## Implementation
- New `ChatTabsBar` component with tab management
- `openSessionIds` state in App.tsx tracks which sessions are tab-open
- Keyboard shortcut handlers for Cmd+T and Ctrl+Tab

## Test plan
- [ ] Cmd+T creates a new tab
- [ ] Ctrl+Tab cycles between tabs
- [ ] Closing a tab activates the adjacent one
- [ ] Renaming a tab updates the session title
- [ ] All existing tests pass

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)