### PR TITLE
fix(#232): redact sensitive error details from server logs by default

### DIFF
--- a/apps/server/src/middleware/error-handler.ts
+++ b/apps/server/src/middleware/error-handler.ts
@@ -11,8 +11,15 @@ export interface AppError {
  * Catches all unhandled errors and returns consistent JSON responses.
  */
 export const errorHandler: ErrorHandler = (err, c) => {
-  // Log the full error to stderr for debugging
-  console.error('[error-handler]', err);
+  // Log the full error to stderr for debugging (only in debug mode)
+  const DEBUG_LOGS_ENABLED = process.env.CLAUDE_TAURI_DEBUG_LOGS === '1';
+  if (DEBUG_LOGS_ENABLED) {
+    console.error('[error-handler]', err);
+  } else {
+    const status = (err as any).status ?? 500;
+    const msg = err instanceof Error ? err.message.split('\n')[0] : 'Internal error';
+    console.error(`[error-handler] ${status} ${msg}`);
+  }
 
   // Determine if this is actually an Error object
   if (!(err instanceof Error)) {

--- a/apps/server/src/routes/sessions.ts
+++ b/apps/server/src/routes/sessions.ts
@@ -16,6 +16,8 @@ import { generateRandomName } from '../services/name-generator';
 import { generateSessionTitle } from '../services/auto-namer';
 import { generateContextSummary } from '../services/context-summary';
 
+const DEBUG_LOGS_ENABLED = process.env.CLAUDE_TAURI_DEBUG_LOGS === '1';
+
 const createSessionSchema = z.object({
   title: z.string().max(500).optional(),
   model: z.string().max(200).optional(),
@@ -268,7 +270,11 @@ export function createSessionsRouter(db: Database) {
       const summary = await generateContextSummary(messages);
       return c.json({ summary });
     } catch (err) {
-      console.error('[summary] Failed to generate summary:', err);
+      if (DEBUG_LOGS_ENABLED) {
+        console.error('[summary] Failed to generate summary:', err);
+      } else {
+        console.error('[summary] Failed to generate summary:', err instanceof Error ? err.message.split('\n')[0] : 'unknown error');
+      }
       return c.json(
         { error: 'Failed to generate summary', code: 'GENERATION_ERROR' },
         500
@@ -311,7 +317,11 @@ export function createSessionsRouter(db: Database) {
       updateSessionTitle(db, id, title);
       return c.json({ title });
     } catch (err) {
-      console.error('[auto-name] Failed to generate title:', err);
+      if (DEBUG_LOGS_ENABLED) {
+        console.error('[auto-name] Failed to generate title:', err);
+      } else {
+        console.error('[auto-name] Failed to generate title:', err instanceof Error ? err.message.split('\n')[0] : 'unknown error');
+      }
       return c.json(
         { error: 'Failed to generate title', code: 'GENERATION_ERROR' },
         500


### PR DESCRIPTION
## Summary
- Gates full error object logging behind CLAUDE_TAURI_DEBUG_LOGS=1 in sessions.ts and error-handler.ts
- By default (production), only logs safe error summary: status code + first line of message
- Follows existing pattern from chat.ts CHAT_DEBUG_LOGS_ENABLED

## Files changed
- apps/server/src/routes/sessions.ts — 2 console.error calls now redacted by default
- apps/server/src/middleware/error-handler.ts — full Error object logging now gated

## Audit
The original audit found 3 files with logging gaps. This PR fixes the 2 HIGH severity ones:
- sessions.ts: AI generation error objects could contain prompt context
- error-handler.ts: Full Error stack traces could leak server internals

The LOW severity gap (startup port log in index.ts) is intentional ops logging — left as-is.

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)