### PR TITLE
feat(#104): MCP server status display and tool call attribution

### DIFF
--- a/apps/desktop/src/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/components/chat/ChatInput.tsx
@@ -6,6 +6,7 @@ import { X, FileText, Paperclip } from 'lucide-react';
 import type { Command } from '@/hooks/useCommands';
 import { isImageFile } from './file-utils';
 import { useSettings } from '@/hooks/useSettings';
+import { McpStatusPill } from './McpStatusPill';
 
 export interface AttachedImage {
   id: string;
@@ -36,6 +37,8 @@ interface ChatInputProps {
   onAcceptSuggestion?: () => void;
   /** Haiku-generated one-line summary of what the conversation is about */
   contextSummary?: string | null;
+  /** Names of enabled non-internal MCP servers to show in the toolbar */
+  mcpServerNames?: string[];
 }
 
 let imageIdCounter = 0;
@@ -171,6 +174,7 @@ export function ChatInput({
   ghostText,
   onAcceptSuggestion,
   contextSummary,
+  mcpServerNames,
 }: ChatInputProps) {
   const { settings } = useSettings();
   const paletteRef = useRef<HTMLDivElement>(null);
@@ -603,6 +607,9 @@ export function ChatInput({
         />
 
         <div className="flex items-center gap-1.5">
+          {mcpServerNames && mcpServerNames.length > 0 && (
+            <McpStatusPill serverNames={mcpServerNames} />
+          )}
           <Button
             type="button"
             size="icon"

--- a/apps/desktop/src/components/chat/ChatPage.tsx
+++ b/apps/desktop/src/components/chat/ChatPage.tsx
@@ -29,6 +29,7 @@ import { CostDisplay } from './CostDisplay';
 import { useCostTracking } from '@/hooks/useCostTracking';
 import { useSuggestions } from '@/hooks/useSuggestions';
 import { useContextSummary } from '@/hooks/useContextSummary';
+import { useMcpServers } from '@/hooks/useMcpServers';
 import { useCheckpoints } from '@/hooks/useCheckpoints';
 import { SuggestionChips } from './SuggestionChips';
 import { useSettings } from '@/hooks/useSettings';
@@ -440,6 +441,8 @@ export function ChatPage({
   } = useSuggestions(messages, { onAccept: handleSuggestionAccept });
 
   const { summary: contextSummary } = useContextSummary(sessionId, messages, isLoading);
+
+  const { visibleEnabledServers: mcpServers } = useMcpServers();
 
   const handleAcceptGhostText = useCallback(() => {
     if (currentSuggestion) {
@@ -1387,6 +1390,7 @@ export function ChatPage({
         ghostText={undefined}
         onAcceptSuggestion={handleAcceptGhostText}
         contextSummary={isLoading ? undefined : contextSummary}
+        mcpServerNames={mcpServers.map((s) => s.name)}
       />
       <ShortcutHelpModal
         isOpen={helpOpen}

--- a/apps/desktop/src/components/chat/McpStatusPill.tsx
+++ b/apps/desktop/src/components/chat/McpStatusPill.tsx
@@ -1,0 +1,73 @@
+import { useState, useRef, useEffect } from 'react';
+
+interface McpStatusPillProps {
+  serverNames: string[];
+}
+
+/**
+ * Compact pill shown in the chat composer toolbar when there are enabled
+ * non-internal MCP servers. Clicking it opens a small dropdown listing them.
+ */
+export function McpStatusPill({ serverNames }: McpStatusPillProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    function handleClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        data-testid="mcp-status-pill"
+        onClick={() => setOpen((prev) => !prev)}
+        className="flex items-center gap-1 rounded-full border border-border bg-muted/40 px-2 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        title={`${serverNames.length} MCP server${serverNames.length !== 1 ? 's' : ''} active`}
+      >
+        {/* Green dot */}
+        <span className="h-1.5 w-1.5 rounded-full bg-green-500" aria-hidden="true" />
+        <span>{serverNames.length} MCP{serverNames.length !== 1 ? 's' : ''}</span>
+      </button>
+
+      {open && (
+        <div
+          data-testid="mcp-status-dropdown"
+          className="absolute bottom-full left-0 z-20 mb-1.5 min-w-[160px] rounded-lg border border-border bg-popover py-1 shadow-lg"
+        >
+          <p className="px-3 py-1 text-xs font-medium text-muted-foreground">Active MCP servers</p>
+          <ul>
+            {serverNames.map((name) => (
+              <li
+                key={name}
+                className="flex items-center gap-2 px-3 py-1 text-xs text-foreground"
+              >
+                <span className="h-1.5 w-1.5 rounded-full bg-green-500 shrink-0" aria-hidden="true" />
+                {name}
+              </li>
+            ))}
+          </ul>
+          <div className="mt-1 border-t border-border/50 px-3 py-1">
+            <a
+              href="https://modelcontextprotocol.io"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2"
+            >
+              MCP documentation
+            </a>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/chat/ToolCallBlock.tsx
+++ b/apps/desktop/src/components/chat/ToolCallBlock.tsx
@@ -22,6 +22,19 @@ import {
 } from './gen-ui/toolData';
 import { BrowserAutomationDisplay, isBrowserAutomationTool } from './BrowserAutomationDisplay';
 
+/**
+ * MCP tools use the naming convention `mcp__<server>__<tool>`.
+ * Returns parsed parts when it matches, otherwise null.
+ */
+function parseMcpTool(toolName: string): { serverName: string; toolName: string } | null {
+  const match = toolName.match(/^mcp__([^_]+(?:_[^_]+)*)__(.+)$/);
+  if (!match) return null;
+  return {
+    serverName: match[1].replace(/_/g, '-'),
+    toolName: match[2],
+  };
+}
+
 export interface ToolCallBlockProps {
   toolCall: ToolCallState;
   onFixErrors?: (toolCall: ToolCallState) => void;
@@ -72,7 +85,9 @@ function StatusIndicator({ status }: { status: ToolCallState['status'] }) {
 
 function GenericToolFallback({ toolCall }: ToolCallBlockProps) {
   const [isExpanded, setIsExpanded] = useState(toolCall.status === 'running');
+  const mcpParts = parseMcpTool(toolCall.name);
   const Icon = getToolIcon(toolCall.name);
+  const displayName = mcpParts ? mcpParts.toolName : toolCall.name;
 
   return (
     <div className="my-2 rounded-lg border border-border bg-muted/30 text-sm overflow-hidden">
@@ -87,7 +102,15 @@ function GenericToolFallback({ toolCall }: ToolCallBlockProps) {
           <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
         )}
         <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
-        <span className="font-medium text-foreground">{sanitizeDisplayText(toolCall.name)}</span>
+        {mcpParts && (
+          <span
+            data-testid="mcp-server-badge"
+            className="rounded bg-blue-500/15 px-1 py-0.5 text-xs font-medium text-blue-400"
+          >
+            {mcpParts.serverName}
+          </span>
+        )}
+        <span className="font-medium text-foreground">{sanitizeDisplayText(displayName)}</span>
 
         {toolCall.summary && !isExpanded ? (
           <span className="ml-1 truncate text-xs text-muted-foreground">

--- a/apps/desktop/src/hooks/useMcpServers.ts
+++ b/apps/desktop/src/hooks/useMcpServers.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+
+const API_BASE = 'http://localhost:3131';
+
+export interface McpServerInfo {
+  name: string;
+  type: 'stdio' | 'http' | 'sse';
+  enabled: boolean;
+  isInternal?: boolean;
+}
+
+export function useMcpServers() {
+  const [servers, setServers] = useState<McpServerInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetch(`${API_BASE}/api/mcp/servers`)
+      .then((r) => r.json())
+      .then((data: { servers?: McpServerInfo[] }) => {
+        if (!cancelled) {
+          setServers(data.servers ?? []);
+          setLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  /** MCP servers that are enabled and not internal infrastructure servers. */
+  const visibleEnabledServers = servers.filter((s) => s.enabled && !s.isInternal);
+
+  return { servers, visibleEnabledServers, loading };
+}

--- a/apps/server/src/routes/mcp.ts
+++ b/apps/server/src/routes/mcp.ts
@@ -92,12 +92,27 @@ async function writeMcpJson(data: McpJsonFile): Promise<void> {
   await Bun.write(getMcpJsonPath(), JSON.stringify(data, null, 2) + '\n');
 }
 
-function toServerConfig(name: string, entry: McpJsonEntry): McpServerConfig {
+/** Names or commands that identify internal/infrastructure MCP servers. */
+const INTERNAL_SERVER_NAMES = new Set(['claude-code', 'claude', 'claude-code-mcp']);
+const INTERNAL_COMMANDS = new Set(['claude', 'claude-code']);
+
+function isInternalServer(name: string, entry: McpJsonEntry): boolean {
+  if (INTERNAL_SERVER_NAMES.has(name.toLowerCase())) return true;
+  if (entry.command && INTERNAL_COMMANDS.has(entry.command.toLowerCase())) return true;
+  return false;
+}
+
+interface McpServerConfigWithMeta extends McpServerConfig {
+  isInternal?: boolean;
+}
+
+function toServerConfig(name: string, entry: McpJsonEntry): McpServerConfigWithMeta {
   const serverType = entry.type || 'stdio';
-  const config: McpServerConfig = {
+  const config: McpServerConfigWithMeta = {
     name,
     type: serverType,
     enabled: !entry.disabled,
+    isInternal: isInternalServer(name, entry),
   };
 
   if (serverType === 'stdio') {


### PR DESCRIPTION
## Summary

- **MCP status pill in composer toolbar**: compact pill showing count of enabled non-internal MCP servers, with a click-to-expand dropdown listing server names and a link to MCP documentation
- **MCP tool call attribution**: `ToolCallBlock` now parses `mcp__<server>__<tool>` tool names and renders a server-name badge before the tool name so users can see which MCP server handled a call
- **Backend `isInternal` flag**: the GET /api/mcp/servers response now includes `isInternal: true` for servers named `claude-code`/`claude` or using those as their command, so the Claude Code infrastructure server is hidden from user-facing displays
- **`useMcpServers` hook**: fetches the server list and provides `visibleEnabledServers` (enabled + not internal) ready for the composer

## Acceptance Criteria

- [x] MCP server statuses appear before sending messages (pill in composer toolbar)
- [x] MCPs from .mcp.json recognized and loaded (existing, unchanged)
- [x] MCP tool calls displayed in chat UI with server attribution badge
- [x] MCP status dropdown with documentation link
- [x] Hide Claude Code MCP servers when using alternative agents (`isInternal` flag)

## Test results

- `ToolCallBlock.test.tsx`: 12/12 pass (unchanged)
- Pre-existing ChatInput/ChatPage test failures (placeholder mismatch): 13 failures that existed before this PR

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)