### PR TITLE
docs(#271): define boilerplate contract, security model, and extension points

### DIFF
--- a/docs/specs/boilerplate-contract.md
+++ b/docs/specs/boilerplate-contract.md
@@ -1,0 +1,48 @@
+# Boilerplate Contract
+
+What every descendant app inherits and what can be customized.
+
+## Required Components
+
+Every derivative **must** retain:
+
+| Component | Path | Why |
+|-----------|------|-----|
+| Tauri desktop shell | `apps/desktop/src-tauri/` | Window lifecycle, IPC bridge, capability enforcement |
+| Sidecar server | `apps/server/` | Auth, API routing, DB; runs as bundled binary |
+| Auth flow | `apps/desktop/src/components/auth/` + server middleware | Token issuance, session management |
+| Shared package | `packages/shared/` | Type contracts between renderer and server |
+| Security config | `tauri.conf.json` `security` section + `capabilities/` | CSP, IPC permissions (see `security-model.md`) |
+
+Removing any of the above breaks the trust model or build pipeline.
+
+## Optional / Removable
+
+| Component | Notes |
+|-----------|-------|
+| Settings panels (`components/settings/`) | Remove or replace freely |
+| Linear integration (`components/linear/`) | Drop if unused |
+| Teams UI (`components/teams/`) | Drop if single-user |
+| Agent builder (`components/agent-builder/`) | Drop if not needed |
+| Workspace UI (`components/workspaces/`) | Replaceable; keep workspace setup contract |
+
+## Version & Dependency Rules
+
+1. **Tauri v2** -- do not downgrade to v1; capability model depends on v2.
+2. **Node sidecar** -- pin major version in `package.json`; keep `externalBin` entry in `tauri.conf.json`.
+3. **Shared types** -- `packages/shared` is the single source of truth for API contracts. Never duplicate types in `apps/`.
+4. **Lock files** -- commit `pnpm-lock.yaml` and `Cargo.lock`. Reproducible builds are mandatory.
+
+## Quality Gates
+
+Every PR must pass **all** of the following before merge:
+
+- `pnpm typecheck` -- zero errors across workspaces
+- `pnpm test` -- all unit/integration tests green
+- `pnpm build` -- production build succeeds for both renderer and server
+- `cargo clippy` -- no warnings in Tauri Rust code
+- **Security config assertions**:
+  - CSP in `tauri.conf.json` is not `null` (see `security-model.md`)
+  - `capabilities/default.json` uses scoped permissions (no `shell:default`)
+  - No plaintext secrets in committed files (`.env.example` has placeholders only)
+- **Bundle check** -- `externalBin` entry for server binary exists in `tauri.conf.json`

--- a/docs/specs/extension-points.md
+++ b/docs/specs/extension-points.md
@@ -1,0 +1,65 @@
+# Extension Points
+
+How to safely extend the boilerplate without breaking the contract.
+
+## Adding a New Settings Panel
+
+1. Create a component in `apps/desktop/src/components/settings/`.
+2. Register it in the settings router/layout (follow existing panel pattern).
+3. If the panel needs server-side config, add a route (see below) and a shared type.
+4. No capability changes needed -- settings panels are renderer-only.
+
+## Adding New API Routes
+
+1. Create a route file in `apps/server/src/routes/`.
+2. Register it in `apps/server/src/index.ts`.
+3. Define request/response types in `packages/shared/`.
+4. All routes must:
+   - Pass through auth middleware (Bearer token validation).
+   - Validate input (use Zod or equivalent).
+   - Return typed responses matching the shared contract.
+5. No direct filesystem or shell access from routes. Use service layer abstractions.
+
+## Adding New Integrations
+
+### MCP Servers
+1. Add the MCP server config to `.mcp.json`.
+2. Implement a client wrapper in `apps/server/src/services/`.
+3. Expose via API routes (see above).
+4. Document required environment variables in `.env.example`.
+
+### External APIs
+1. Add a service in `apps/server/src/services/`.
+2. Store API keys in environment variables, never hardcoded.
+3. Add types to `packages/shared/` for any data surfaced to the renderer.
+4. Rate-limit and error-handle at the service layer.
+
+## Customizing the Workspace Setup Contract
+
+1. Workspace logic lives in `apps/desktop/src/components/workspaces/`.
+2. The workspace setup flow can be replaced entirely -- it is optional (see `boilerplate-contract.md`).
+3. If you change the workspace data model, update:
+   - Server DB schema (`apps/server/src/db/`).
+   - Shared types (`packages/shared/`).
+   - Any API routes that reference workspace data.
+4. Keep workspace creation idempotent -- the UI may retry on failure.
+
+## Adding New Tauri Capabilities
+
+This is the highest-risk extension. Follow this process:
+
+1. **Identify the minimum permission** needed. Prefer scoped variants (e.g., `fs:allow-read` with a path scope over `fs:default`).
+2. **Add to `capabilities/default.json`** (or create a new capability file for separation).
+3. **Document why** the capability is needed in a PR description.
+4. **Review checklist** before merge:
+   - [ ] No blanket permissions (`*:default` patterns).
+   - [ ] Scoped to specific windows if possible.
+   - [ ] Does not weaken existing security model (see `security-model.md`).
+   - [ ] Tested with `cargo tauri build` -- capability validation passes.
+5. **Never add `shell:default`**, `fs:default`, or `http:default`. Always use scoped alternatives.
+
+## General Rules for All Extensions
+
+- Types flow through `packages/shared/`. Do not create parallel type definitions.
+- Test new functionality: unit tests for services, integration tests for routes.
+- Run all quality gates from `boilerplate-contract.md` before opening a PR.

--- a/docs/specs/security-model.md
+++ b/docs/specs/security-model.md
@@ -1,0 +1,62 @@
+# Security Model
+
+Trust boundaries and rules that descendant apps must not weaken.
+
+## Trust Boundaries
+
+```
++------------------+       IPC (Tauri invoke)       +------------------+
+|   Renderer       | <---------------------------->  |   Tauri Core     |
+|   (webview)      |   capability-gated commands     |   (Rust)         |
++------------------+                                 +------------------+
+        |                                                    |
+        | HTTP + Bearer token                                | spawns
+        v                                                    v
++------------------+                                 +------------------+
+|   Sidecar Server |                                 |   OS / FS        |
+|   (Node.js)      |                                 +------------------+
++------------------+
+```
+
+- **Renderer**: untrusted. May load external content. Never grant direct OS access.
+- **Sidecar server**: semi-trusted. Runs as a child process with scoped permissions.
+- **Tauri core (Rust)**: trusted. Mediates all privileged operations via capabilities.
+- **OS**: fully trusted. Tauri core is the only bridge.
+
+## CSP Requirements
+
+- `tauri.conf.json` `app.security.csp` **must not be `null`**.
+- Minimum policy: `default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'`.
+- No `unsafe-eval` in production builds.
+- Descendant apps must tighten, never loosen, the CSP.
+
+> **Current state**: CSP is `null` in the boilerplate. Issue tracked -- descendants must fix before shipping.
+
+## Credential Storage
+
+- **Secrets** (API keys, tokens): store via OS keychain (`tauri-plugin-stronghold` or platform keyring). Never in `localStorage`, `SQLite`, or flat files.
+- **Session tokens**: hold in memory only. Persist refresh tokens in keychain if needed.
+- **`.env` files**: never committed. `.env.example` contains placeholders only.
+
+## Shell Capability Rules
+
+- Use **scoped** shell permissions: `shell:allow-spawn`, `shell:allow-kill`, `shell:allow-stdin-write`.
+- **Never** use `shell:default` (blanket shell access).
+- Every new shell command must be added to an explicit allow-list in `capabilities/`.
+- Sidecar binary path must be declared in `externalBin`; no arbitrary binary execution.
+
+## Transport Security (Renderer <-> Sidecar)
+
+- All HTTP requests from the renderer to the sidecar must include a **Bearer token** in the `Authorization` header.
+- The sidecar must validate the token on every request via auth middleware.
+- Sidecar listens on `127.0.0.1` only; never bind `0.0.0.0`.
+- Use HTTPS in production if the sidecar is exposed beyond localhost.
+
+## What Descendants Must NOT Weaken
+
+1. Do not set CSP to `null` or add `unsafe-eval`.
+2. Do not grant `shell:default` or unscoped IPC permissions.
+3. Do not store secrets in `localStorage`, cookies, or SQLite.
+4. Do not remove Bearer token validation from sidecar middleware.
+5. Do not bind the sidecar to `0.0.0.0`.
+6. Do not bypass Tauri's capability model with custom IPC bridges.


### PR DESCRIPTION
## Summary
Closes #271

Creates three spec documents defining the descendant-app inheritance model:

- **`docs/specs/boilerplate-contract.md`** — required vs optional components, quality gates, version rules
- **`docs/specs/security-model.md`** — trust boundaries, CSP requirements, credential storage rules, transport security
- **`docs/specs/extension-points.md`** — how to add settings panels, API routes, integrations, and Tauri capabilities

## Test plan
- [ ] Review spec docs for accuracy against current codebase
- [ ] Verify extension point instructions are actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)