### PR TITLE
refactor(#273): split ChatPage.tsx into sub-components and hooks

### DIFF
--- a/apps/desktop/src/components/chat/ChatPage.tsx
+++ b/apps/desktop/src/components/chat/ChatPage.tsx
@@ -1,1305 +1,113 @@
-import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
-import { useChat } from '@ai-sdk/react';
-import { DefaultChatTransport } from 'ai';
-import type { UIMessage } from '@ai-sdk/react';
-import type { Message, PermissionResponse } from '@claude-tauri/shared';
-import { pickProviderConfig } from '@claude-tauri/shared';
 import { MessageList } from './MessageList';
-import type { AssistantResponseMetadata } from './MessageList';
 import { ChatInput } from './ChatInput';
-import { ErrorBanner, type ChatError } from './ErrorBanner';
+import { ErrorBanner } from './ErrorBanner';
 import { PermissionDialog } from './PermissionDialog';
 import { PlanView } from './PlanView';
 import { SubagentPanel } from './SubagentPanel';
 import { RewindDialog } from './RewindDialog';
 import { LatestTurnChangesDialog } from './LatestTurnChangesDialog';
-import type { RewindMode } from './RewindDialog';
-import type { PermissionDecisionResult } from './PermissionDialog';
-import { useStreamEvents } from '@/hooks/useStreamEvents';
-import type { UsageState } from '@/hooks/useStreamEvents';
-import { useSubagents } from '@/hooks/useSubagents';
-import { useCommands } from '@/hooks/useCommands';
-import { useCommandPalette } from '@/hooks/useCommandPalette';
-import { useKeyboardShortcuts, type ShortcutDefinition } from '@/hooks/useKeyboardShortcuts';
 import { ShortcutHelpModal } from '@/components/ShortcutHelpModal';
-import { ContextIndicator } from './ContextIndicator';
-import type { ContextUsage } from './ContextIndicator';
-import { CostDisplay } from './CostDisplay';
-import { useCostTracking } from '@/hooks/useCostTracking';
-import { useSuggestions } from '@/hooks/useSuggestions';
-import { useContextSummary } from '@/hooks/useContextSummary';
-import { useMcpServers } from '@/hooks/useMcpServers';
-import { useCheckpoints } from '@/hooks/useCheckpoints';
 import { SuggestionChips } from './SuggestionChips';
-import { useSettings } from '@/hooks/useSettings';
-import { calculateCost, getModelFromName } from '@/lib/pricing';
-import type { PlanDecisionRequest, Checkpoint, RewindPreview } from '@claude-tauri/shared';
-import type { ToolCallState } from '@/hooks/useStreamEvents';
-import { useWorkspaceDiff } from '@/hooks/useWorkspaceDiff';
-import * as workspaceApi from '@/lib/workspace-api';
-import { generateArtifact } from '@/lib/workspace-api';
-import { toast } from 'sonner';
-import { DashboardPromptModal } from '@/components/workspaces/DashboardPromptModal';
-import type { AttachedImage } from './ChatInput';
 import { LinearIssuePicker } from '@/components/linear/LinearIssuePicker';
-import type { CreateWorkspaceRequest } from '@claude-tauri/shared';
-import * as linearApi from '@/lib/linear-api';
-import { promptMemoryUpdate } from '@/lib/memoryUpdatePrompt';
-import { X } from '@phosphor-icons/react';
+import { DashboardPromptModal } from '@/components/workspaces/DashboardPromptModal';
+import { CostDialog } from './CostDialog';
+import { LinearIssueBar } from './LinearIssueBar';
+import { CommandTipBanner } from './CommandTipBanner';
+import { useChatPageState } from './useChatPageState';
+import { useChatPageHandlers } from './chatPageHandlers';
 import './gen-ui/defaultRenderers';
-import {
-  getWorkflowPrompt,
-  buildReviewMemoryDraft,
-  buildReviewWorkflowMessage,
-  buildPrWorkflowMessage,
-  buildBranchNameWorkflowMessage,
-  buildBrowserWorkflowMessage,
-} from '@/lib/workflowPrompts';
-import { getApiBase, getAuthHeaders, apiFetch } from '@/lib/api-config';
-const PLAN_EXPORT_DRAFT_KEY = 'claude-tauri-plan-export-draft';
 
-export interface ChatPageStatusData {
-  model: string | null;
-  isStreaming: boolean;
-  toolCalls: Map<string, import('@/hooks/useStreamEvents').ToolCallState>;
-  cumulativeUsage: import('@/hooks/useStreamEvents').CumulativeUsage;
-  sessionTotalCost: number;
-  subagentActiveCount: number;
-  checkpoints: import('@claude-tauri/shared').Checkpoint[];
-  sessionInfo?: {
-    sessionId: string;
-    model: string;
-    tools: string[];
-    mcpServers: Array<{ name: string; status: string }>;
-    claudeCodeVersion: string;
-  } | null;
-}
+// Re-export types that external consumers may need
+export type { ChatPageStatusData, ChatPageProps } from './chatPageTypes';
+export type { LinearIssueContext } from './chatPageTypes';
 
-type LinearIssueContext = NonNullable<CreateWorkspaceRequest['linearIssue']>;
+import type { ChatPageProps } from './chatPageTypes';
 
-interface ChatPageProps {
-  sessionId: string | null;
-  onCreateSession?: () => void | Promise<void>;
-  onExportSession?: () => void | Promise<void>;
-  onStatusChange?: (data: ChatPageStatusData) => void;
-  onAutoName?: (sessionId: string) => void;
-  workspaceId?: string;
-  projectId?: string;
-  additionalDirectories?: string[];
-  onToggleSidebar?: () => void;
-  onOpenSettings?: (tab?: string) => void;
-  onOpenSessions?: () => void;
-  onOpenPullRequests?: () => void;
-  onOpenWorkspacePaths?: (path?: string) => void;
-  /** Called when a root-level agent task reaches a terminal status */
-  onTaskComplete?: (params: {
-    status: 'completed' | 'failed' | 'stopped';
-    summary: string;
-  }) => void;
-  /** Agent profile ID to use for this chat */
-  profileId?: string | null;
-  /** Available agent profiles for selection */
-  agentProfiles?: import('@claude-tauri/shared').AgentProfile[];
-  /** Callback when user selects a different profile */
-  onSelectProfile?: (id: string | null) => void;
-  /** Initial message to auto-send when the page mounts */
-  initialMessage?: string | null;
-  /** Called after the initial message has been consumed */
-  onInitialMessageConsumed?: () => void;
-  /** Called when backend initializes the app session ID */
-  onSessionInitialized?: (sessionId: string) => void;
-}
+export function ChatPage(props: ChatPageProps) {
+  const { sessionId, onOpenSettings, projectId } = props;
 
-function extractCommandFromToolInput(input: string): string | undefined {
-  if (!input) return undefined;
+  const state = useChatPageState(props);
+  const handlers = useChatPageHandlers(state, props);
 
-  try {
-    const parsed = JSON.parse(input);
-    if (typeof parsed === 'string') return parsed;
-    if (typeof parsed.command === 'string') return parsed.command;
-    if (Array.isArray(parsed.command)) return parsed.command.join(' ');
-  } catch {
-    return input;
-  }
-
-  return undefined;
-}
-
-/**
- * Convert a persisted Message (from the DB) into a UIMessage
- * that the AI SDK useChat hook understands.
- */
-function toUIMessage(msg: Message): UIMessage {
-  return {
-    id: msg.id,
-    role: msg.role,
-    parts: [{ type: 'text' as const, text: msg.content }],
-  };
-}
-
-function getLatestAssistantMessageId(messages: UIMessage[]): string | null {
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    if (messages[index].role === 'assistant') {
-      return messages[index].id;
-    }
-  }
-
-  return null;
-}
-
-export function ChatPage({
-  sessionId,
-  onCreateSession,
-  onExportSession,
-  onStatusChange,
-  onAutoName,
-  workspaceId,
-  projectId,
-  additionalDirectories,
-  onToggleSidebar,
-  onOpenSettings,
-  onOpenSessions,
-  onOpenPullRequests,
-  onOpenWorkspacePaths,
-  onTaskComplete,
-  profileId,
-  agentProfiles: _agentProfiles,
-  onSelectProfile: _onSelectProfile,
-  initialMessage,
-  onInitialMessageConsumed,
-  onSessionInitialized,
-}: ChatPageProps) {
-  const { settings, updateSettings } = useSettings();
-  const [input, setInput] = useState('');
-  const [attachments, setAttachments] = useState<AttachedImage[]>([]);
-  const [linearIssue, setLinearIssue] = useState<LinearIssueContext | null>(null);
-  const [linearPickerOpen, setLinearPickerOpen] = useState(false);
-  const [helpOpen, setHelpOpen] = useState(false);
-  const [costOpen, setCostOpen] = useState(false);
-  const [thinkingExpanded, setThinkingExpanded] = useState(false);
-  const [thinkingToggleVersion, setThinkingToggleVersion] = useState(0);
-  const [dashboardModalOpen, setDashboardModalOpen] = useState(false);
-  const [dashboardModalLoading, setDashboardModalLoading] = useState(false);
-  const [dashboardModalError, setDashboardModalError] = useState<string | null>(null);
   const {
+    settings,
+    updateSettings,
+    input,
+    attachments,
+    setAttachments,
+    linearIssue,
+    setLinearIssue,
+    linearPickerOpen,
+    setLinearPickerOpen,
+    helpOpen,
+    setHelpOpen,
+    costOpen,
+    setCostOpen,
+    thinkingExpanded,
+    thinkingToggleVersion,
+    dashboardModalOpen,
+    setDashboardModalOpen,
+    dashboardModalLoading,
+    dashboardModalError,
+    setDashboardModalError,
     toolCalls,
     thinkingBlocks,
-    pendingPermissions,
-    resolvePermission,
     plan,
-    approvePlan,
-    rejectPlan,
-    cumulativeUsage,
-    isCompacting,
-    usage,
-    sessionInfo,
-    processEvent,
-    reset: resetStreamEvents,
-  } = useStreamEvents();
-
-  const {
-    agents: subagents,
-    activeCount: subagentActiveCount,
-    isVisible: subagentPanelVisible,
-    toggleVisibility: toggleSubagentPanel,
-    reset: resetSubagents,
-  } = useSubagents({
-    onRootTaskComplete: onTaskComplete,
-  });
-
-  const {
+    isLoading,
+    messages,
+    subagents,
+    subagentActiveCount,
+    subagentPanelVisible,
+    toggleSubagentPanel,
     messageCosts,
     sessionTotalCost,
-    addMessageCost,
-    reset: resetCostTracking,
-  } = useCostTracking();
-
-  const {
-    diff: workspaceDiff,
-    changedFiles,
-    fetchDiff: fetchWorkspaceDiff,
-  } = useWorkspaceDiff(workspaceId ?? null);
-  const suggestedFiles = useMemo(
-    () => changedFiles.map((file) => file.path),
-    [changedFiles]
-  );
-
-  useEffect(() => {
-    if (!workspaceId) return;
-    void fetchWorkspaceDiff();
-  }, [workspaceId, fetchWorkspaceDiff]);
-
-  // Checkpoint tracking state
-  const lastUserPromptRef = useRef('');
-  const lastUserMessageIdRef = useRef('');
-  const initialMessageSentRef = useRef(false);
-  const [rewindTarget, setRewindTarget] = useState<Checkpoint | null>(null);
-  const [rewindPreview, setRewindPreview] = useState<RewindPreview | null>(null);
-  const [isLoadingPreview, setIsLoadingPreview] = useState(false);
-  const [latestChangesOpen, setLatestChangesOpen] = useState(false);
-  const [latestChangesLoading, setLatestChangesLoading] = useState(false);
-  const [latestChangesDiff, setLatestChangesDiff] = useState('');
-  const [latestChangesError, setLatestChangesError] = useState<string | null>(null);
-  const [archivedPlanId, setArchivedPlanId] = useState<string | null>(null);
-  const [archivedPlanPath, setArchivedPlanPath] = useState<string | null>(null);
-  const [assistantMetadata, setAssistantMetadata] = useState<
-    Record<string, AssistantResponseMetadata>
-  >({});
-
-  // Auto-naming: track user message count per session
-  const userMsgCountRef = useRef(0);
-  const autoNameCalledRef = useRef(false);
-  const prevSessionIdRef = useRef(sessionId);
-
-  // Reset counters when session changes
-  if (sessionId !== prevSessionIdRef.current) {
-    prevSessionIdRef.current = sessionId;
-    userMsgCountRef.current = 0;
-    autoNameCalledRef.current = false;
-  }
-
-  // Claude's context window is 200k tokens
-  const MAX_CONTEXT_TOKENS = 200_000;
-
-  const contextUsage: ContextUsage = useMemo(
-    () => ({
-      inputTokens: cumulativeUsage.inputTokens,
-      outputTokens: cumulativeUsage.outputTokens,
-      cacheReadTokens: cumulativeUsage.cacheReadTokens,
-      cacheCreationTokens: cumulativeUsage.cacheCreationTokens,
-      maxTokens: MAX_CONTEXT_TOKENS,
-    }),
-    [cumulativeUsage]
-  );
-
-  // Record cost when a session:result event provides usage data
-  const lastRecordedUsageRef = useRef<UsageState | null>(null);
-
-  const transport = useMemo(
-    () =>
-      new DefaultChatTransport({
-        api: `${getApiBase()}/api/chat`,
-        headers: getAuthHeaders(),
-        body: {
-          sessionId,
-          model: settings.model,
-          effort: settings.fastMode ? 'low' : settings.effort,
-          thinkingBudgetTokens: settings.thinkingBudgetTokens,
-          permissionMode: settings.permissionMode,
-          provider: settings.provider,
-          runtimeEnv: settings.runtimeEnv,
-          systemPrompt: settings.systemPrompt || undefined,
-          providerConfig: pickProviderConfig(settings.provider, settings),
-          ...(workspaceId ? { workspaceId } : {}),
-          ...(additionalDirectories && additionalDirectories.length > 0
-            ? { additionalDirectories }
-            : {}),
-          ...(linearIssue ? { linearIssue } : {}),
-          ...(profileId ? { profileId } : {}),
-        },
-      }),
-    [
-      sessionId,
-      settings.model,
-      settings.effort,
-      settings.fastMode,
-      settings.thinkingBudgetTokens,
-      settings.permissionMode,
-      settings.provider,
-      settings.runtimeEnv,
-      settings.systemPrompt,
-      settings.bedrockBaseUrl,
-      settings.bedrockProjectId,
-      settings.vertexProjectId,
-      settings.vertexBaseUrl,
-      settings.customBaseUrl,
-      workspaceId,
-      additionalDirectories,
-      linearIssue,
-      profileId,
-    ]
-  );
-
-  // Deep-link: #linear/issue/ENG-123 preselects a Linear issue context for this chat.
-  useEffect(() => {
-    const match = window.location.hash.match(/^#linear\/issue\/([^/?#]+)$/);
-    if (!match?.[1]) return;
-    const identifier = decodeURIComponent(match[1]);
-
-    let cancelled = false;
-    (async () => {
-      try {
-        const issue = await linearApi.getIssue(identifier);
-        if (cancelled) return;
-        setLinearIssue({
-          id: issue.id,
-          title: issue.title,
-          summary: issue.summary,
-          url: issue.url,
-        });
-      } catch {
-        // ignore
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  // Stable chat ID: never changes after mount. The SDK uses this as an
-  // internal store key — changing it recreates the Chat object and drops state.
-  // We pass sessionId to the server via transport.body instead.
-  const [chatId] = useState<string>(
-    () => sessionId ?? (typeof crypto !== 'undefined' && crypto.randomUUID
-      ? crypto.randomUUID()
-      : `fallback-${Date.now()}-${Math.random().toString(36).slice(2)}`)
-  );
-
-  // Handle data-stream-event parts from the AI SDK data channel.
-  const handleDataPart = useCallback(
-    (part: { type: string; data?: unknown }) => {
-      if (part.type === 'data-stream-event' && part.data && typeof part.data === 'object' && 'type' in part.data) {
-        if ((part.data as { type: string }).type === 'session:init') {
-          const event = part.data as { type: 'session:init'; sessionId?: string };
-          if (typeof event.sessionId === 'string' && event.sessionId.trim().length > 0) {
-            onSessionInitialized?.(event.sessionId);
-          }
-        }
-        processEvent(part.data as import('@claude-tauri/shared').StreamEvent);
-      }
-    },
-    [processEvent, onSessionInitialized]
-  );
-
-  const { messages, sendMessage, status, setMessages, error, clearError } =
-    useChat({
-      id: chatId,
-      transport,
-      onData: handleDataPart as any,
-    });
-
-  // Note: chatId is stable for the lifetime of this mount. The real sessionId
-  // is passed to the server via transport.body.sessionId, so server-side
-  // session association works correctly even though the SDK's internal key
-  // is different from the server session ID.
-
-  useEffect(() => {
-    if (usage && usage !== lastRecordedUsageRef.current) {
-      lastRecordedUsageRef.current = usage;
-      const model = sessionInfo?.model ?? 'claude-sonnet-4';
-      const latestAssistantId = getLatestAssistantMessageId(messages);
-      const costUsd =
-        usage.costUsd > 0
-          ? usage.costUsd
-          : calculateCost(
-              {
-                inputTokens: usage.inputTokens,
-                outputTokens: usage.outputTokens,
-                cacheReadTokens: usage.cacheReadTokens,
-                cacheCreationTokens: usage.cacheCreationTokens,
-              },
-              getModelFromName(model)
-            );
-
-      addMessageCost({
-        messageId: `turn-${Date.now()}`,
-        model,
-        inputTokens: usage.inputTokens,
-        outputTokens: usage.outputTokens,
-        cacheReadTokens: usage.cacheReadTokens,
-        cacheCreationTokens: usage.cacheCreationTokens,
-        costUsd,
-        durationMs: usage.durationMs,
-      });
-
-      if (latestAssistantId) {
-        setAssistantMetadata((current) => ({
-          ...current,
-          [latestAssistantId]: {
-            changedFiles: current[latestAssistantId]?.changedFiles ?? [],
-            model,
-            durationMs: usage.durationMs,
-            inputTokens: usage.inputTokens,
-            outputTokens: usage.outputTokens,
-            cacheReadTokens: usage.cacheReadTokens,
-            cacheCreationTokens: usage.cacheCreationTokens,
-          },
-        }));
-      }
-    }
-  }, [usage, sessionInfo, addMessageCost, messages]);
-
-  const isLoading = status === 'submitted' || status === 'streaming';
-
-  const {
-    checkpoints,
-    previewRewind,
-    executeRewind,
-    reset: resetCheckpoints,
-  } = useCheckpoints({
-    sessionId,
-    toolCalls,
-    lastUserPrompt: lastUserPromptRef.current,
-    userMessageId: lastUserMessageIdRef.current,
-    isStreaming: isLoading,
-  });
-
-  // Prompt suggestions based on last assistant message
-  const handleSuggestionAccept = useCallback(
-    (suggestion: string) => {
-      setInput(suggestion);
-    },
-    []
-  );
-
-  const {
+    suggestedFiles,
+    rewindTarget,
+    rewindPreview,
+    isLoadingPreview,
+    latestChangesOpen,
+    setLatestChangesOpen,
+    latestChangesLoading,
+    latestChangesDiff,
+    latestChangesError,
+    archivedPlanPath,
+    assistantMetadata,
     suggestions,
-    currentSuggestion,
-    accept: acceptSuggestion,
-    dismiss: dismissSuggestion,
-    dismissAll: dismissAllSuggestions,
-  } = useSuggestions(messages, { onAccept: handleSuggestionAccept });
-
-  const { summary: contextSummary } = useContextSummary(sessionId, messages, isLoading);
-
-  const { visibleEnabledServers: mcpServers } = useMcpServers();
-
-  const handleAcceptGhostText = useCallback(() => {
-    if (currentSuggestion) {
-      acceptSuggestion(currentSuggestion);
-    }
-  }, [currentSuggestion, acceptSuggestion]);
-
-  const handleSuggestionChipSelect = useCallback(
-    (suggestion: string) => {
-      setInput(suggestion);
-    },
-    []
-  );
-
-  const composePromptWithAttachments = useCallback(
-    (text: string, files: AttachedImage[]) => {
-      if (!files.length) return text;
-
-      const mentioned = new Set((text.match(/@([^\s]+)/g) || []).map((match) => match.slice(1)));
-      const additional = files.filter(
-        (file) =>
-          !mentioned.has(file.name) &&
-          !mentioned.has(file.name.split('/').pop() || '')
-      );
-      if (!additional.length) return text;
-
-      const lines = additional.map((file) => `- @${file.name}`);
-      return `${text}\n\nAttached files:\n${lines.join('\n')}`;
-    },
-    []
-  );
-
-  // Command palette integration
-  const clearChat = useCallback(() => {
-    setMessages([]);
-    setAssistantMetadata({});
-    resetStreamEvents();
-    resetCostTracking();
-    resetSubagents();
-    resetCheckpoints();
-    lastUserPromptRef.current = '';
-    lastUserMessageIdRef.current = '';
-    setAttachments([]);
-  }, [setMessages, resetStreamEvents, resetCostTracking, resetSubagents, resetCheckpoints]);
-
-  const runReviewWorkflow = useCallback(async () => {
-    const latest = await fetchWorkspaceDiff();
-    const diff = latest?.diff ?? workspaceDiff;
-    const filePaths = (latest?.changedFiles ?? changedFiles).map((f) => f.path);
-    const prompt = getWorkflowPrompt(settings.workflowPrompts, 'review');
-    const text = buildReviewWorkflowMessage({ prompt, changedFiles: filePaths, diff });
-    await sendMessage({ text } as any);
-  }, [fetchWorkspaceDiff, workspaceDiff, changedFiles, settings.workflowPrompts, sendMessage]);
-
-  const runPrWorkflow = useCallback(async () => {
-    const latest = await fetchWorkspaceDiff();
-    const diff = latest?.diff ?? workspaceDiff;
-    const prompt = getWorkflowPrompt(settings.workflowPrompts, 'pr');
-    const text = buildPrWorkflowMessage({ prompt, diff });
-    await sendMessage({ text } as any);
-  }, [fetchWorkspaceDiff, workspaceDiff, settings.workflowPrompts, sendMessage]);
-
-  const runBranchWorkflow = useCallback(async () => {
-    const latest = await fetchWorkspaceDiff();
-    const filePaths = (latest?.changedFiles ?? changedFiles).map((f) => f.path);
-    const prompt = getWorkflowPrompt(settings.workflowPrompts, 'branch');
-    const text = buildBranchNameWorkflowMessage({ prompt, changedFiles: filePaths });
-    await sendMessage({ text } as any);
-  }, [fetchWorkspaceDiff, changedFiles, settings.workflowPrompts, sendMessage]);
-
-  const runBrowserWorkflow = useCallback(
-    async (task?: string) => {
-      const prompt = getWorkflowPrompt(settings.workflowPrompts, 'browser');
-      const text = buildBrowserWorkflowMessage({
-        prompt,
-        targetUrl: 'http://localhost:1420',
-        task,
-      });
-      await sendMessage({ text } as any);
-    },
-    [settings.workflowPrompts, sendMessage]
-  );
-
-  const handleDashboardModalConfirm = useCallback(
-    async (prompt: string) => {
-      if (!workspaceId || !projectId) return;
-      setDashboardModalLoading(true);
-      setDashboardModalError(null);
-      try {
-        const result = await generateArtifact(projectId, {
-          prompt,
-          workspaceId,
-          sessionId: sessionId ?? undefined,
-        });
-        toast.success(`Dashboard "${result.artifact.title}" created`);
-        setDashboardModalOpen(false);
-      } catch (err) {
-        setDashboardModalError(err instanceof Error ? err.message : 'Failed to generate dashboard');
-      } finally {
-        setDashboardModalLoading(false);
-      }
-    },
-    [workspaceId, projectId, sessionId]
-  );
-
-  const generateDashboard = useCallback(
-    workspaceId && projectId
-      ? () => {
-          setDashboardModalError(null);
-          setDashboardModalOpen(true);
-        }
-      : async () => {
-          toast.info('Open a workspace to generate dashboard artifacts');
-        },
-    [workspaceId, projectId]
-  );
-
-  const commandContext = useMemo(
-    () => ({
-      clearChat,
-      createSession: onCreateSession ?? (() => {}),
-      exportSession: onExportSession ?? (() => {}),
-      showHelp: () => setHelpOpen(true),
-      showSettings: onOpenSettings,
-      showModelSelector: onOpenSettings ? () => onOpenSettings('model') : undefined,
-      showCostSummary: () => setCostOpen(true),
-      showSessionList: onOpenSessions,
-      openPullRequests: onOpenPullRequests,
-      showLinearIssues: () => setLinearPickerOpen(true),
-      addDir: onOpenWorkspacePaths,
-      runReviewWorkflow,
-      runPrWorkflow,
-      runBranchWorkflow,
-      runBrowserWorkflow,
-      generateDashboard,
-    }),
-    [
-      clearChat,
-      onCreateSession,
-      onExportSession,
-      onOpenSettings,
-      onOpenSessions,
-      onOpenPullRequests,
-      onOpenWorkspacePaths,
-      runReviewWorkflow,
-      runPrWorkflow,
-      runBranchWorkflow,
-      runBrowserWorkflow,
-      generateDashboard,
-    ]
-  );
-
-  const { commands, filterCommands } = useCommands(commandContext);
+    contextSummary,
+    mcpServers,
+  } = state;
 
   const {
-    isOpen: paletteOpen,
-    searchQuery: paletteFilter,
+    paletteOpen,
+    paletteFilter,
     filteredCommands,
-    close: closePalette,
-    handleInputChange: handlePaletteInput,
-    handleCommandSelect,
-  } = useCommandPalette({ commands, filterCommands });
-
-  const handleInputChange = useCallback(
-    (value: string) => {
-      setInput(value);
-      handlePaletteInput(value);
-    },
-    [handlePaletteInput]
-  );
-
-  const handleCommandSelectAndClear = useCallback(
-    (cmd: typeof commands[number]) => {
-      setInput('');
-      handleCommandSelect(cmd);
-    },
-    [handleCommandSelect]
-  );
-
-  const handlePaletteClose = useCallback(() => {
-    setInput('');
-    closePalette();
-  }, [closePalette]);
-
-  const toggleThinkingVisibility = useCallback(() => {
-    updateSettings({ showThinking: !settings.showThinking });
-  }, [settings.showThinking, updateSettings]);
-
-  const toggleThinkingExpanded = useCallback(() => {
-    setThinkingExpanded((prev) => !prev);
-    setThinkingToggleVersion((prev) => prev + 1);
-  }, []);
-
-  // Keyboard shortcuts
-  const shortcutDefs: ShortcutDefinition[] = useMemo(
-    () => [
-      {
-        id: 'new-session',
-        key: 'n',
-        meta: true,
-        label: 'New Session',
-        category: 'chat' as const,
-        handler: () => onCreateSession?.(),
-      },
-      {
-        id: 'clear-chat',
-        key: 'l',
-        meta: true,
-        label: 'Clear Chat',
-        category: 'chat' as const,
-        handler: clearChat,
-      },
-      {
-        id: 'toggle-sidebar',
-        key: '/',
-        meta: true,
-        label: 'Toggle Sidebar',
-        category: 'navigation' as const,
-        handler: onToggleSidebar ?? (() => {}),
-      },
-      {
-        id: 'settings',
-        key: ',',
-        meta: true,
-        label: 'Open Settings',
-        category: 'navigation' as const,
-        handler: onOpenSettings ?? (() => {}),
-      },
-      {
-        id: 'help',
-        key: '?',
-        meta: true,
-        shift: true,
-        label: 'Show Help',
-        category: 'general' as const,
-        handler: () => setHelpOpen((prev) => !prev),
-      },
-      {
-        id: 'thinking-visibility',
-        key: 't',
-        alt: true,
-        label: 'Toggle thinking visibility',
-        category: 'chat' as const,
-        handler: toggleThinkingVisibility,
-      },
-      {
-        id: 'thinking-expand',
-        key: '.',
-        meta: true,
-        shift: true,
-        label: 'Expand thinking blocks',
-        category: 'chat' as const,
-        handler: toggleThinkingExpanded,
-      },
-      {
-        id: 'escape',
-        key: 'Escape',
-        label: 'Cancel / Close',
-        category: 'general' as const,
-        handler: () => {
-          if (costOpen) {
-            setCostOpen(false);
-          } else if (helpOpen) {
-            setHelpOpen(false);
-          } else if (paletteOpen) {
-            handlePaletteClose();
-          }
-        },
-      },
-    ],
-    [
-      onCreateSession,
-      clearChat,
-      costOpen,
-      helpOpen,
-      paletteOpen,
-      handlePaletteClose,
-      onToggleSidebar,
-      onOpenSettings,
-      toggleThinkingVisibility,
-      toggleThinkingExpanded,
-    ]
-  );
-
-  const { shortcuts } = useKeyboardShortcuts(shortcutDefs);
-
-  // Load persisted messages when the session changes
-  useEffect(() => {
-    if (!sessionId) {
-      setMessages([]);
-      setAssistantMetadata({});
-      return;
-    }
-
-    setMessages([]);
-    setAssistantMetadata({});
-
-    let cancelled = false;
-
-    async function loadMessages() {
-      try {
-        const res = await fetch(
-          `${API_BASE}/api/sessions/${sessionId}/messages`
-        );
-        if (!res.ok) return;
-
-        const saved: Message[] = await res.json();
-        if (cancelled) return;
-
-        setMessages(saved.map(toUIMessage));
-      } catch {
-        // Server not reachable — leave messages empty
-      }
-    }
-
-    loadMessages();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [sessionId, setMessages]);
-
-  // Track when streaming completes to trigger auto-naming
-  const wasStreamingRef = useRef(false);
-  useEffect(() => {
-    if (isLoading) {
-      wasStreamingRef.current = true;
-    } else if (wasStreamingRef.current) {
-      // Streaming just ended
-      wasStreamingRef.current = false;
-      const completedAssistantId = getLatestAssistantMessageId(messages);
-      if (workspaceId && completedAssistantId) {
-        void fetchWorkspaceDiff().then((latest) => {
-          const changedFilesForTurn =
-            latest?.changedFiles?.map((file) => file.path) ?? [];
-          setAssistantMetadata((current) => {
-            const existing = current[completedAssistantId];
-            if (!existing) return current;
-
-            return {
-              ...current,
-              [completedAssistantId]: {
-                ...existing,
-                changedFiles: changedFilesForTurn,
-              },
-            };
-          });
-        });
-      }
-
-      userMsgCountRef.current += 1;
-      if (
-        userMsgCountRef.current >= 1 &&
-        !autoNameCalledRef.current &&
-        sessionId &&
-        onAutoName
-      ) {
-        autoNameCalledRef.current = true;
-        onAutoName(sessionId);
-      }
-    }
-  }, [isLoading, sessionId, onAutoName, messages, workspaceId, fetchWorkspaceDiff]);
-
-  // Report status data to parent for StatusBar
-  useEffect(() => {
-    onStatusChange?.({
-      model: sessionInfo?.model ?? null,
-      isStreaming: isLoading,
-      toolCalls,
-      cumulativeUsage,
-      sessionTotalCost,
-      subagentActiveCount,
-      checkpoints,
-      sessionInfo: sessionInfo ?? null,
-    });
-  }, [sessionInfo, isLoading, toolCalls, cumulativeUsage, sessionTotalCost, subagentActiveCount, checkpoints, onStatusChange]);
-
-  const chatError: ChatError | null = useMemo(() => {
-    if (!error) return null;
-
-    const rawMsg = error.message || 'An unexpected error occurred';
-    const lowerMsg = rawMsg.toLowerCase();
-
-    // Log the full technical error for debugging
-    console.error('[ChatPage] Error details:', rawMsg);
-
-    // Sanitize technical/internal errors into user-friendly messages
-    const isTechnicalError =
-      lowerMsg.includes('circular structure') ||
-      lowerMsg.includes('fibernode') ||
-      lowerMsg.includes('htmlelement') ||
-      lowerMsg.includes('converting circular') ||
-      lowerMsg.includes('stack trace') ||
-      lowerMsg.includes('typeerror') ||
-      lowerMsg.includes('referenceerror') ||
-      lowerMsg.includes('syntaxerror') ||
-      lowerMsg.includes('cannot read propert');
-
-    const msg = isTechnicalError
-      ? 'Something went wrong sending your message. Please try again.'
-      : rawMsg;
-
-    if (lowerMsg.includes('rate limit') || lowerMsg.includes('429')) {
-      return { type: 'rate_limit', message: msg, retryable: true };
-    }
-    if (
-      lowerMsg.includes('auth') ||
-      lowerMsg.includes('401') ||
-      lowerMsg.includes('403')
-    ) {
-      return { type: 'auth', message: msg, retryable: false };
-    }
-    if (
-      lowerMsg.includes('network') ||
-      lowerMsg.includes('fetch') ||
-      lowerMsg.includes('econnrefused') ||
-      lowerMsg.includes('econnreset')
-    ) {
-      return { type: 'network', message: msg, retryable: true };
-    }
-    return { type: 'api', message: msg, retryable: true };
-  }, [error]);
-
-  const handleRetry = useCallback(() => {
-    clearError();
-    const lastUserMessage = [...messages]
-      .reverse()
-      .find((m) => m.role === 'user');
-    if (!lastUserMessage) return;
-
-    const text = lastUserMessage.parts
-      ?.filter((p): p is { type: 'text'; text: string } => p.type === 'text')
-      .map((p) => p.text)
-      .join('');
-
-    if (text) {
-      resetStreamEvents();
-      sendMessage({ text });
-    }
-  }, [messages, clearError, sendMessage, resetStreamEvents]);
-
-  const handleDismissError = useCallback(() => {
-    clearError();
-  }, [clearError]);
-
-  const handlePermissionDecision = useCallback(
-    async (result: PermissionDecisionResult) => {
-      if (!sessionId) return;
-      resolvePermission(result.requestId);
-
-      try {
-        await apiFetch(`/api/chat/permission`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            sessionId,
-            requestId: result.requestId,
-            decision: result.decision,
-            scope: result.scope,
-          } satisfies PermissionResponse),
-        });
-      } catch (err) {
-        console.error('[permission] Failed to send decision:', err);
-      }
-    },
-    [sessionId, resolvePermission]
-  );
-
-  const handlePlanApprove = useCallback(async () => {
-    if (!plan) return;
-    if (!sessionId) return;
-    approvePlan(plan.planId);
-
-    try {
-      await apiFetch(`/api/chat/plan`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          sessionId,
-          planId: plan.planId,
-          decision: 'approve',
-        } satisfies PlanDecisionRequest),
-      });
-    } catch (err) {
-      console.error('[plan] Failed to send approval:', err);
-    }
-  }, [sessionId, plan, approvePlan]);
-
-  const buildPlanDraft = useCallback(
-    (heading: string) => {
-      if (!plan) return '';
-      return [
-        heading,
-        archivedPlanPath ? `Plan file: ${archivedPlanPath}` : undefined,
-        '',
-        plan.content,
-      ]
-        .filter((value): value is string => Boolean(value))
-        .join('\n');
-    },
-    [plan, archivedPlanPath]
-  );
-
-  const handlePlanReject = useCallback(
-    async (feedback?: string) => {
-      if (!plan) return;
-      if (!sessionId) return;
-      rejectPlan(plan.planId, feedback);
-
-      try {
-        await apiFetch(`/api/chat/plan`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          sessionId,
-          planId: plan.planId,
-          decision: 'reject',
-          feedback,
-        } satisfies PlanDecisionRequest),
-      });
-        if (feedback?.trim()) {
-          const prompt = getWorkflowPrompt(
-            settings.workflowPrompts,
-            'reviewMemory'
-          );
-          promptMemoryUpdate({
-            trigger: 'review-feedback',
-            draft: {
-              fileName: 'MEMORY.md',
-              content: buildReviewMemoryDraft({
-                prompt,
-                feedback,
-              }),
-            },
-            onOpenMemory: () => onOpenSettings?.('memory'),
-          });
-        }
-      } catch (err) {
-        console.error('[plan] Failed to send rejection:', err);
-      }
-    },
-    [sessionId, plan, rejectPlan, onOpenSettings, settings.workflowPrompts]
-  );
-
-  const handlePlanApproveWithFeedback = useCallback(
-    async (feedback?: string) => {
-      if (!plan) return;
-      if (!sessionId) return;
-      approvePlan(plan.planId);
-
-      try {
-        await apiFetch(`/api/chat/plan`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          sessionId,
-          planId: plan.planId,
-          decision: 'approve',
-          feedback,
-        } satisfies PlanDecisionRequest),
-      });
-        if (feedback?.trim()) {
-          const prompt = getWorkflowPrompt(
-            settings.workflowPrompts,
-            'reviewMemory'
-          );
-          promptMemoryUpdate({
-            trigger: 'review-feedback',
-            draft: {
-              fileName: 'MEMORY.md',
-              content: buildReviewMemoryDraft({
-                prompt,
-                feedback,
-              }),
-            },
-            onOpenMemory: () => onOpenSettings?.('memory'),
-          });
-        }
-      } catch (err) {
-        console.error('[plan] Failed to send approval feedback:', err);
-      }
-    },
-    [sessionId, plan, approvePlan, onOpenSettings, settings.workflowPrompts]
-  );
-
-  const handlePlanInput = useCallback(
-    async (feedback: string) => {
-      const text = feedback.trim();
-      if (!text) return;
-
-      resetStreamEvents();
-      await sendMessage({
-        text: `Continue planning with this user input:\n${text}`,
-      } as any);
-    },
-    [resetStreamEvents, sendMessage]
-  );
-
-  const handlePlanCopy = useCallback(async () => {
-    const text = buildPlanDraft('Copy of current plan');
-    if (!text) return;
-    await navigator.clipboard.writeText(text);
-  }, [buildPlanDraft]);
-
-  const handlePlanExportToNewChat = useCallback(async () => {
-    const draft = buildPlanDraft('Implement this approved plan');
-    if (!draft) return;
-
-    window.sessionStorage.setItem(PLAN_EXPORT_DRAFT_KEY, draft);
-    if (onCreateSession) {
-      await onCreateSession();
-      return;
-    }
-
-    setInput(draft);
-  }, [buildPlanDraft, onCreateSession]);
-
-  const handlePlanHandoff = useCallback(async () => {
-    const text = buildPlanDraft('Handoff to another agent');
-    if (!text) return;
-    await navigator.clipboard.writeText(text);
-  }, [buildPlanDraft]);
-
-  useEffect(() => {
-    if (!plan || !sessionId) return;
-    if (!plan.content.trim()) return;
-    if (plan.planId === archivedPlanId) return;
-    if (plan.status !== 'review' && plan.status !== 'approved' && plan.status !== 'rejected') {
-      return;
-    }
-
-    let cancelled = false;
-
-    void apiFetch(`/api/chat/plan/archive`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        sessionId,
-        planId: plan.planId,
-        content: plan.content,
-      }),
-    })
-      .then(async (response) => {
-        if (!response.ok) return null;
-        return (await response.json()) as { path?: string };
-      })
-      .then((result) => {
-        if (cancelled || !result?.path) return;
-        setArchivedPlanId(plan.planId);
-        setArchivedPlanPath(result.path);
-      })
-      .catch((error) => {
-        console.error('[plan] Failed to archive plan:', error);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [plan, sessionId, archivedPlanId]);
-
-  useEffect(() => {
-    const draft = window.sessionStorage.getItem(PLAN_EXPORT_DRAFT_KEY);
-    if (!draft) return;
-    if (input.trim().length > 0) return;
-
-    setInput(draft);
-    window.sessionStorage.removeItem(PLAN_EXPORT_DRAFT_KEY);
-  }, [sessionId]);
-
-  const handleFixErrors = useCallback(
-    async (toolCall: ToolCallState) => {
-      if (!toolCall.ciFailures) return;
-
-      const command = extractCommandFromToolInput(toolCall.input);
-      const checks =
-        toolCall.ciFailures.checks.length > 0
-          ? `\nFailing checks:\n${toolCall.ciFailures.checks
-              .map((item) => `- ${item}`)
-              .join('\n')}`
-          : '';
-      const commandLine = command ? `\nLast command: ${command}` : '';
-      const prompt =
-        `The previous CI checks failed. Please fix the issues and rerun validation.${checks}${commandLine}\n\nRaw logs:\n${toolCall.ciFailures.rawOutput}`;
-
-      resetStreamEvents();
-      setInput('');
-      await sendMessage({ text: prompt });
-    },
-    [isLoading, resetStreamEvents, sendMessage]
-  );
-
-  const pendingPermissionEntries = useMemo(
-    () => Array.from(pendingPermissions.values()),
-    [pendingPermissions]
-  );
-
-  // Rewind dialog handlers
-  const handleRewindClick = useCallback(
-    async (checkpointId: string) => {
-      const cp = checkpoints.find((c) => c.id === checkpointId);
-      if (!cp) return;
-      setRewindTarget(cp);
-      setIsLoadingPreview(true);
-      const preview = await previewRewind(checkpointId);
-      setRewindPreview(preview);
-      setIsLoadingPreview(false);
-    },
-    [checkpoints, previewRewind]
-  );
-
-  const handleRewindConfirm = useCallback(
-    async (mode: RewindMode) => {
-      if (!rewindTarget) return;
-      const ok = await executeRewind(rewindTarget.id, mode);
-      if (ok && sessionId) {
-        try {
-          const res = await apiFetch(`/api/sessions/${sessionId}/messages`);
-          if (res.ok) {
-            const saved: Message[] = await res.json();
-            setMessages(saved.map(toUIMessage));
-          }
-        } catch {
-          // ignore
-        }
-
-        if (workspaceId) {
-          void fetchWorkspaceDiff();
-        }
-      }
-      setRewindTarget(null);
-      setRewindPreview(null);
-    },
-    [rewindTarget, executeRewind, sessionId, setMessages, workspaceId, fetchWorkspaceDiff]
-  );
-
-  const handleRewindCancel = useCallback(() => {
-    setRewindTarget(null);
-    setRewindPreview(null);
-  }, []);
-
-  const handleViewLatestChanges = useCallback(
-    async (range: { fromRef: string; toRef: string }) => {
-      if (!workspaceId) return;
-      setLatestChangesOpen(true);
-      setLatestChangesLoading(true);
-      setLatestChangesError(null);
-      try {
-        const result = await workspaceApi.fetchWorkspaceDiff(workspaceId, range);
-        setLatestChangesDiff(result.diff);
-      } catch (err) {
-        setLatestChangesError(err instanceof Error ? err.message : 'Failed to load diff');
-        setLatestChangesDiff('');
-      } finally {
-        setLatestChangesLoading(false);
-      }
-    },
-    [workspaceId]
-  );
-
-  const handleSubmit = async () => {
-    const text = input.trim();
-    if (!text || isLoading) return;
-
-    if (text.startsWith('/')) {
-      const commandToken = text.slice(1).trim().split(/\s+/)[0]?.toLowerCase() ?? '';
-      if (commandToken) {
-        const matchedCommand = commands.find(
-          (cmd) => cmd.name.toLowerCase() === commandToken
-        );
-        if (matchedCommand) {
-          const commandArgs = text.slice(commandToken.length + 1).trim();
-          setInput('');
-          if (commandToken === 'add-dir' && onOpenWorkspacePaths) {
-            onOpenWorkspacePaths(commandArgs || undefined);
-            return;
-          }
-          if (commandToken === 'browser') {
-            resetStreamEvents();
-            await runBrowserWorkflow(commandArgs);
-            return;
-          }
-          handleCommandSelect(matchedCommand);
-          return;
-        }
-
-        const pluginCommands = new Set(
-          (sessionInfo?.slashCommands ?? []).map((command) => command.toLowerCase())
-        );
-        if (!pluginCommands.has(commandToken)) {
-          setMessages(prev => [
-            ...prev,
-            {
-              id: `invalid-slash-${Date.now()}`,
-              role: 'assistant',
-              parts: [
-                {
-                  type: 'text',
-                  text: `Invalid slash command: /${commandToken}`,
-                },
-              ],
-            } as UIMessage,
-          ]);
-          return;
-        }
-      }
-    }
-
-    // Track turn info for checkpoints
-    const payload = composePromptWithAttachments(text, attachments);
-    lastUserPromptRef.current = text;
-    lastUserMessageIdRef.current = `user-${Date.now()}`;
-
-    setInput('');
-    resetStreamEvents();
-    setAttachments([]);
-    await sendMessage({ text: payload });
-  };
-
-  // Auto-send initial message from WelcomeScreen
-  useEffect(() => {
-    if (!initialMessage) {
-      initialMessageSentRef.current = false;
-      return;
-    }
-
-    if (initialMessageSentRef.current) {
-      return;
-    }
-
-    initialMessageSentRef.current = true;
-    onInitialMessageConsumed?.();
-    resetStreamEvents();
-    lastUserPromptRef.current = initialMessage;
-    lastUserMessageIdRef.current = `user-${Date.now()}`;
-    void sendMessage({ text: initialMessage } as any);
-  }, [initialMessage, onInitialMessageConsumed, resetStreamEvents, sendMessage]);
+    handleInputChange,
+    handleCommandSelectAndClear,
+    handlePaletteClose,
+    shortcuts,
+    chatError,
+    handleRetry,
+    handleDismissError,
+    handlePermissionDecision,
+    pendingPermissionEntries,
+    handlePlanApprove,
+    handlePlanReject,
+    handlePlanInput,
+    handlePlanCopy,
+    handlePlanExportToNewChat,
+    handlePlanHandoff,
+    handleFixErrors,
+    handleRewindConfirm,
+    handleRewindCancel,
+    handleAcceptGhostText,
+    handleSuggestionChipSelect,
+    handleDashboardModalConfirm,
+    handleSubmit,
+  } = handlers;
+
+  const showCommandTip =
+    !settings.hasDismissedCommandTip &&
+    messages.some((m) => m.role === 'assistant');
 
   return (
     <div className="flex flex-1 flex-col min-w-0 min-h-0">
@@ -1316,6 +124,7 @@ export function ChatPage({
         sessionId={sessionId}
         projectId={projectId}
       />
+
       {/* Subagent visualization panel */}
       {(subagents.length > 0 || subagentPanelVisible) && (
         <SubagentPanel
@@ -1325,6 +134,7 @@ export function ChatPage({
           onToggleVisibility={toggleSubagentPanel}
         />
       )}
+
       <LatestTurnChangesDialog
         open={latestChangesOpen}
         loading={latestChangesLoading}
@@ -1332,6 +142,7 @@ export function ChatPage({
         error={latestChangesError}
         onClose={() => setLatestChangesOpen(false)}
       />
+
       {/* Rewind dialog */}
       {rewindTarget && (
         <RewindDialog
@@ -1342,12 +153,14 @@ export function ChatPage({
           onCancel={handleRewindCancel}
         />
       )}
+
       {/* Error banner */}
       <ErrorBanner
         error={chatError}
         onDismiss={handleDismissError}
         onRetry={handleRetry}
       />
+
       {/* Plan view */}
       {plan && plan.status !== 'idle' && (
         <div className="border-t border-border px-4 py-2">
@@ -1363,6 +176,7 @@ export function ChatPage({
           />
         </div>
       )}
+
       {/* Permission dialogs */}
       {pendingPermissionEntries.length > 0 && (
         <div className="border-t border-border px-4 py-2 space-y-2">
@@ -1378,51 +192,36 @@ export function ChatPage({
           ))}
         </div>
       )}
+
       {/* Suggestion chips */}
       {suggestions.length > 0 && !isLoading && (
         <SuggestionChips
           suggestions={suggestions}
           onSelect={handleSuggestionChipSelect}
-          onDismiss={dismissSuggestion}
+          onDismiss={state.dismissSuggestion}
         />
       )}
-      {linearIssue ? (
-        <div className="border-t border-border px-4 py-2 flex items-center gap-2">
-          <div className="text-xs text-muted-foreground shrink-0">Issue:</div>
-          <button
-            className="text-xs font-mono text-primary hover:underline underline-offset-2 truncate"
-            onClick={() => setLinearPickerOpen(true)}
-            title={linearIssue.title}
-          >
-            {linearIssue.id}
-          </button>
-          <div className="text-xs text-muted-foreground truncate">{linearIssue.title}</div>
-          <button
-            className="ml-auto rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-accent hover:text-foreground"
-            onClick={() => {
-              setLinearIssue(null);
-              if (window.location.hash.startsWith('#linear/issue/')) window.location.hash = '';
-            }}
-          >
-            Clear
-          </button>
-        </div>
-      ) : null}
-      {!settings.hasDismissedCommandTip && messages.some((m) => m.role === 'assistant') && (
-        <div className="border-t border-border bg-muted/50 text-sm px-4 py-2 flex items-center justify-between">
-          <span className="text-muted-foreground">
-            Pro tip: Type <kbd className="mx-0.5 rounded border border-border bg-background px-1 py-0.5 font-mono text-xs">/</kbd> to access commands like /review, /compact, and /pr
-          </span>
-          <button
-            type="button"
-            onClick={() => updateSettings({ hasDismissedCommandTip: true })}
-            className="ml-2 rounded-md p-0.5 text-muted-foreground hover:text-foreground hover:bg-accent"
-            aria-label="Dismiss tip"
-          >
-            <X className="h-4 w-4" />
-          </button>
-        </div>
+
+      {/* Linear issue context bar */}
+      {linearIssue && (
+        <LinearIssueBar
+          linearIssue={linearIssue}
+          onOpenPicker={() => setLinearPickerOpen(true)}
+          onClear={() => {
+            setLinearIssue(null);
+            if (window.location.hash.startsWith('#linear/issue/'))
+              window.location.hash = '';
+          }}
+        />
       )}
+
+      {/* Command tip */}
+      {showCommandTip && (
+        <CommandTipBanner
+          onDismiss={() => updateSettings({ hasDismissedCommandTip: true })}
+        />
+      )}
+
       {/* Footer composer */}
       <div className="relative border-t border-border bg-background/95 backdrop-blur-sm z-20 px-4 py-4 flex flex-col items-center">
         <ChatInput
@@ -1444,42 +243,19 @@ export function ChatPage({
           mcpServerNames={mcpServers.map((s) => s.name)}
         />
       </div>
+
       <ShortcutHelpModal
         isOpen={helpOpen}
         onClose={() => setHelpOpen(false)}
         shortcuts={shortcuts}
       />
+
       {costOpen && (
-        <div
-          data-testid="cost-dialog-backdrop"
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-          onClick={() => setCostOpen(false)}
-        >
-          <div
-            data-testid="cost-dialog"
-            className="w-80 rounded-xl border border-border bg-background p-6 shadow-xl"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <h2 className="mb-4 text-lg font-semibold">Session Cost</h2>
-            <div className="space-y-2 text-sm">
-              <div className="flex justify-between">
-                <span className="text-muted-foreground">Total cost</span>
-                <span className="font-mono">${sessionTotalCost.toFixed(6)}</span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-muted-foreground">Messages</span>
-                <span className="font-mono">{messageCosts.length}</span>
-              </div>
-            </div>
-            <button
-              data-testid="cost-dialog-close"
-              onClick={() => setCostOpen(false)}
-              className="mt-4 w-full rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground"
-            >
-              Close
-            </button>
-          </div>
-        </div>
+        <CostDialog
+          sessionTotalCost={sessionTotalCost}
+          messageCostCount={messageCosts.length}
+          onClose={() => setCostOpen(false)}
+        />
       )}
 
       <LinearIssuePicker

--- a/apps/desktop/src/components/chat/CommandTipBanner.tsx
+++ b/apps/desktop/src/components/chat/CommandTipBanner.tsx
@@ -1,0 +1,27 @@
+import { X } from '@phosphor-icons/react';
+
+interface CommandTipBannerProps {
+  onDismiss: () => void;
+}
+
+export function CommandTipBanner({ onDismiss }: CommandTipBannerProps) {
+  return (
+    <div className="border-t border-border bg-muted/50 text-sm px-4 py-2 flex items-center justify-between">
+      <span className="text-muted-foreground">
+        Pro tip: Type{' '}
+        <kbd className="mx-0.5 rounded border border-border bg-background px-1 py-0.5 font-mono text-xs">
+          /
+        </kbd>{' '}
+        to access commands like /review, /compact, and /pr
+      </span>
+      <button
+        type="button"
+        onClick={onDismiss}
+        className="ml-2 rounded-md p-0.5 text-muted-foreground hover:text-foreground hover:bg-accent"
+        aria-label="Dismiss tip"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/chat/CostDialog.tsx
+++ b/apps/desktop/src/components/chat/CostDialog.tsx
@@ -1,0 +1,40 @@
+interface CostDialogProps {
+  sessionTotalCost: number;
+  messageCostCount: number;
+  onClose: () => void;
+}
+
+export function CostDialog({ sessionTotalCost, messageCostCount, onClose }: CostDialogProps) {
+  return (
+    <div
+      data-testid="cost-dialog-backdrop"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={onClose}
+    >
+      <div
+        data-testid="cost-dialog"
+        className="w-80 rounded-xl border border-border bg-background p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="mb-4 text-lg font-semibold">Session Cost</h2>
+        <div className="space-y-2 text-sm">
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Total cost</span>
+            <span className="font-mono">${sessionTotalCost.toFixed(6)}</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Messages</span>
+            <span className="font-mono">{messageCostCount}</span>
+          </div>
+        </div>
+        <button
+          data-testid="cost-dialog-close"
+          onClick={onClose}
+          className="mt-4 w-full rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/chat/LinearIssueBar.tsx
+++ b/apps/desktop/src/components/chat/LinearIssueBar.tsx
@@ -1,0 +1,29 @@
+import type { LinearIssueContext } from './chatPageTypes';
+
+interface LinearIssueBarProps {
+  linearIssue: LinearIssueContext;
+  onOpenPicker: () => void;
+  onClear: () => void;
+}
+
+export function LinearIssueBar({ linearIssue, onOpenPicker, onClear }: LinearIssueBarProps) {
+  return (
+    <div className="border-t border-border px-4 py-2 flex items-center gap-2">
+      <div className="text-xs text-muted-foreground shrink-0">Issue:</div>
+      <button
+        className="text-xs font-mono text-primary hover:underline underline-offset-2 truncate"
+        onClick={onOpenPicker}
+        title={linearIssue.title}
+      >
+        {linearIssue.id}
+      </button>
+      <div className="text-xs text-muted-foreground truncate">{linearIssue.title}</div>
+      <button
+        className="ml-auto rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-accent hover:text-foreground"
+        onClick={onClear}
+      >
+        Clear
+      </button>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/chat/chatPageHandlers.ts
+++ b/apps/desktop/src/components/chat/chatPageHandlers.ts
@@ -1,0 +1,918 @@
+import { useCallback, useMemo, useEffect } from 'react';
+import type { UIMessage } from '@ai-sdk/react';
+import type { Message, PlanDecisionRequest, PermissionResponse } from '@claude-tauri/shared';
+import type { ChatError } from './ErrorBanner';
+import type { PermissionDecisionResult } from './PermissionDialog';
+import type { RewindMode } from './RewindDialog';
+import type { ToolCallState } from '@/hooks/useStreamEvents';
+import type { AttachedImage } from './ChatInput';
+import type { ShortcutDefinition } from '@/hooks/useKeyboardShortcuts';
+import { useCommands } from '@/hooks/useCommands';
+import { useCommandPalette } from '@/hooks/useCommandPalette';
+import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
+import { toast } from 'sonner';
+import { generateArtifact } from '@/lib/workspace-api';
+import * as workspaceApi from '@/lib/workspace-api';
+import { promptMemoryUpdate } from '@/lib/memoryUpdatePrompt';
+import {
+  getWorkflowPrompt,
+  buildReviewMemoryDraft,
+  buildReviewWorkflowMessage,
+  buildPrWorkflowMessage,
+  buildBranchNameWorkflowMessage,
+  buildBrowserWorkflowMessage,
+} from '@/lib/workflowPrompts';
+import {
+  API_BASE,
+  PLAN_EXPORT_DRAFT_KEY,
+  extractCommandFromToolInput,
+  toUIMessage,
+} from './chatPageTypes';
+import type { ChatPageProps } from './chatPageTypes';
+import type { useChatPageState } from './useChatPageState';
+
+type State = ReturnType<typeof useChatPageState>;
+
+export function useChatPageHandlers(state: State, props: ChatPageProps) {
+  const {
+    sessionId,
+    onCreateSession,
+    onExportSession,
+    onOpenSettings,
+    onOpenSessions,
+    onOpenPullRequests,
+    onOpenWorkspacePaths,
+    onToggleSidebar,
+    workspaceId,
+    projectId,
+  } = props;
+
+  const {
+    settings,
+    updateSettings,
+    input,
+    setInput,
+    attachments,
+    setAttachments,
+    setLinearPickerOpen,
+    helpOpen,
+    setHelpOpen,
+    costOpen,
+    setCostOpen,
+    setThinkingExpanded,
+    setThinkingToggleVersion,
+    setDashboardModalOpen,
+    setDashboardModalLoading,
+    setDashboardModalError,
+    plan,
+    approvePlan,
+    rejectPlan,
+    resolvePermission,
+    pendingPermissions,
+    resetStreamEvents,
+    sessionInfo,
+    messages,
+    sendMessage,
+    isLoading,
+    setMessages,
+    error,
+    clearError,
+    setAssistantMetadata,
+    resetCostTracking,
+    resetSubagents,
+    resetCheckpoints,
+    workspaceDiff,
+    changedFiles,
+    fetchWorkspaceDiff,
+    checkpoints,
+    previewRewind,
+    executeRewind,
+    rewindTarget,
+    setRewindTarget,
+    setRewindPreview,
+    setIsLoadingPreview,
+    setLatestChangesOpen,
+    setLatestChangesLoading,
+    setLatestChangesError,
+    setLatestChangesDiff,
+    archivedPlanId,
+    setArchivedPlanId,
+    archivedPlanPath,
+    setArchivedPlanPath,
+    currentSuggestion,
+    acceptSuggestion,
+    lastUserPromptRef,
+    lastUserMessageIdRef,
+  } = state;
+
+  // --------------- Clear chat ---------------
+  const clearChat = useCallback(() => {
+    setMessages([]);
+    setAssistantMetadata({});
+    resetStreamEvents();
+    resetCostTracking();
+    resetSubagents();
+    resetCheckpoints();
+    lastUserPromptRef.current = '';
+    lastUserMessageIdRef.current = '';
+    setAttachments([]);
+  }, [setMessages, resetStreamEvents, resetCostTracking, resetSubagents, resetCheckpoints, setAssistantMetadata, setAttachments, lastUserPromptRef, lastUserMessageIdRef]);
+
+  // --------------- Workflow handlers ---------------
+  const runReviewWorkflow = useCallback(async () => {
+    const latest = await fetchWorkspaceDiff();
+    const diff = latest?.diff ?? workspaceDiff;
+    const filePaths = (latest?.changedFiles ?? changedFiles).map((f) => f.path);
+    const prompt = getWorkflowPrompt(settings.workflowPrompts, 'review');
+    const text = buildReviewWorkflowMessage({ prompt, changedFiles: filePaths, diff });
+    await sendMessage({ text } as any);
+  }, [fetchWorkspaceDiff, workspaceDiff, changedFiles, settings.workflowPrompts, sendMessage]);
+
+  const runPrWorkflow = useCallback(async () => {
+    const latest = await fetchWorkspaceDiff();
+    const diff = latest?.diff ?? workspaceDiff;
+    const prompt = getWorkflowPrompt(settings.workflowPrompts, 'pr');
+    const text = buildPrWorkflowMessage({ prompt, diff });
+    await sendMessage({ text } as any);
+  }, [fetchWorkspaceDiff, workspaceDiff, settings.workflowPrompts, sendMessage]);
+
+  const runBranchWorkflow = useCallback(async () => {
+    const latest = await fetchWorkspaceDiff();
+    const filePaths = (latest?.changedFiles ?? changedFiles).map((f) => f.path);
+    const prompt = getWorkflowPrompt(settings.workflowPrompts, 'branch');
+    const text = buildBranchNameWorkflowMessage({ prompt, changedFiles: filePaths });
+    await sendMessage({ text } as any);
+  }, [fetchWorkspaceDiff, changedFiles, settings.workflowPrompts, sendMessage]);
+
+  const runBrowserWorkflow = useCallback(
+    async (task?: string) => {
+      const prompt = getWorkflowPrompt(settings.workflowPrompts, 'browser');
+      const text = buildBrowserWorkflowMessage({
+        prompt,
+        targetUrl: 'http://localhost:1420',
+        task,
+      });
+      await sendMessage({ text } as any);
+    },
+    [settings.workflowPrompts, sendMessage]
+  );
+
+  // --------------- Dashboard ---------------
+  const handleDashboardModalConfirm = useCallback(
+    async (prompt: string) => {
+      if (!workspaceId || !projectId) return;
+      setDashboardModalLoading(true);
+      setDashboardModalError(null);
+      try {
+        const result = await generateArtifact(projectId, {
+          prompt,
+          workspaceId,
+          sessionId: sessionId ?? undefined,
+        });
+        toast.success(`Dashboard "${result.artifact.title}" created`);
+        setDashboardModalOpen(false);
+      } catch (err) {
+        setDashboardModalError(err instanceof Error ? err.message : 'Failed to generate dashboard');
+      } finally {
+        setDashboardModalLoading(false);
+      }
+    },
+    [workspaceId, projectId, sessionId, setDashboardModalLoading, setDashboardModalError, setDashboardModalOpen]
+  );
+
+  const generateDashboard = useCallback(
+    workspaceId && projectId
+      ? () => {
+          setDashboardModalError(null);
+          setDashboardModalOpen(true);
+        }
+      : async () => {
+          toast.info('Open a workspace to generate dashboard artifacts');
+        },
+    [workspaceId, projectId, setDashboardModalError, setDashboardModalOpen]
+  );
+
+  // --------------- Command palette ---------------
+  const commandContext = useMemo(
+    () => ({
+      clearChat,
+      createSession: onCreateSession ?? (() => {}),
+      exportSession: onExportSession ?? (() => {}),
+      showHelp: () => setHelpOpen(true),
+      showSettings: onOpenSettings,
+      showModelSelector: onOpenSettings ? () => onOpenSettings('model') : undefined,
+      showCostSummary: () => setCostOpen(true),
+      showSessionList: onOpenSessions,
+      openPullRequests: onOpenPullRequests,
+      showLinearIssues: () => setLinearPickerOpen(true),
+      addDir: onOpenWorkspacePaths,
+      runReviewWorkflow,
+      runPrWorkflow,
+      runBranchWorkflow,
+      runBrowserWorkflow,
+      generateDashboard,
+    }),
+    [
+      clearChat,
+      onCreateSession,
+      onExportSession,
+      onOpenSettings,
+      onOpenSessions,
+      onOpenPullRequests,
+      onOpenWorkspacePaths,
+      runReviewWorkflow,
+      runPrWorkflow,
+      runBranchWorkflow,
+      runBrowserWorkflow,
+      generateDashboard,
+      setHelpOpen,
+      setCostOpen,
+      setLinearPickerOpen,
+    ]
+  );
+
+  const { commands, filterCommands } = useCommands(commandContext);
+
+  const {
+    isOpen: paletteOpen,
+    searchQuery: paletteFilter,
+    filteredCommands,
+    close: closePalette,
+    handleInputChange: handlePaletteInput,
+    handleCommandSelect,
+  } = useCommandPalette({ commands, filterCommands });
+
+  const handleInputChange = useCallback(
+    (value: string) => {
+      setInput(value);
+      handlePaletteInput(value);
+    },
+    [setInput, handlePaletteInput]
+  );
+
+  const handleCommandSelectAndClear = useCallback(
+    (cmd: (typeof commands)[number]) => {
+      setInput('');
+      handleCommandSelect(cmd);
+    },
+    [setInput, handleCommandSelect]
+  );
+
+  const handlePaletteClose = useCallback(() => {
+    setInput('');
+    closePalette();
+  }, [setInput, closePalette]);
+
+  // --------------- Thinking toggles ---------------
+  const toggleThinkingVisibility = useCallback(() => {
+    updateSettings({ showThinking: !settings.showThinking });
+  }, [settings.showThinking, updateSettings]);
+
+  const toggleThinkingExpanded = useCallback(() => {
+    setThinkingExpanded((prev: boolean) => !prev);
+    setThinkingToggleVersion((prev: number) => prev + 1);
+  }, [setThinkingExpanded, setThinkingToggleVersion]);
+
+  // --------------- Keyboard shortcuts ---------------
+  const shortcutDefs: ShortcutDefinition[] = useMemo(
+    () => [
+      {
+        id: 'new-session',
+        key: 'n',
+        meta: true,
+        label: 'New Session',
+        category: 'chat' as const,
+        handler: () => onCreateSession?.(),
+      },
+      {
+        id: 'clear-chat',
+        key: 'l',
+        meta: true,
+        label: 'Clear Chat',
+        category: 'chat' as const,
+        handler: clearChat,
+      },
+      {
+        id: 'toggle-sidebar',
+        key: '/',
+        meta: true,
+        label: 'Toggle Sidebar',
+        category: 'navigation' as const,
+        handler: onToggleSidebar ?? (() => {}),
+      },
+      {
+        id: 'settings',
+        key: ',',
+        meta: true,
+        label: 'Open Settings',
+        category: 'navigation' as const,
+        handler: onOpenSettings ?? (() => {}),
+      },
+      {
+        id: 'help',
+        key: '?',
+        meta: true,
+        shift: true,
+        label: 'Show Help',
+        category: 'general' as const,
+        handler: () => setHelpOpen((prev: boolean) => !prev),
+      },
+      {
+        id: 'thinking-visibility',
+        key: 't',
+        alt: true,
+        label: 'Toggle thinking visibility',
+        category: 'chat' as const,
+        handler: toggleThinkingVisibility,
+      },
+      {
+        id: 'thinking-expand',
+        key: '.',
+        meta: true,
+        shift: true,
+        label: 'Expand thinking blocks',
+        category: 'chat' as const,
+        handler: toggleThinkingExpanded,
+      },
+      {
+        id: 'escape',
+        key: 'Escape',
+        label: 'Cancel / Close',
+        category: 'general' as const,
+        handler: () => {
+          if (costOpen) {
+            setCostOpen(false);
+          } else if (helpOpen) {
+            setHelpOpen(false);
+          } else if (paletteOpen) {
+            handlePaletteClose();
+          }
+        },
+      },
+    ],
+    [
+      onCreateSession,
+      clearChat,
+      costOpen,
+      helpOpen,
+      paletteOpen,
+      handlePaletteClose,
+      onToggleSidebar,
+      onOpenSettings,
+      toggleThinkingVisibility,
+      toggleThinkingExpanded,
+      setHelpOpen,
+      setCostOpen,
+    ]
+  );
+
+  const { shortcuts } = useKeyboardShortcuts(shortcutDefs);
+
+  // --------------- Error handling ---------------
+  const chatError: ChatError | null = useMemo(() => {
+    if (!error) return null;
+
+    const rawMsg = error.message || 'An unexpected error occurred';
+    const lowerMsg = rawMsg.toLowerCase();
+
+    console.error('[ChatPage] Error details:', rawMsg);
+
+    const isTechnicalError =
+      lowerMsg.includes('circular structure') ||
+      lowerMsg.includes('fibernode') ||
+      lowerMsg.includes('htmlelement') ||
+      lowerMsg.includes('converting circular') ||
+      lowerMsg.includes('stack trace') ||
+      lowerMsg.includes('typeerror') ||
+      lowerMsg.includes('referenceerror') ||
+      lowerMsg.includes('syntaxerror') ||
+      lowerMsg.includes('cannot read propert');
+
+    const msg = isTechnicalError
+      ? 'Something went wrong sending your message. Please try again.'
+      : rawMsg;
+
+    if (lowerMsg.includes('rate limit') || lowerMsg.includes('429')) {
+      return { type: 'rate_limit', message: msg, retryable: true };
+    }
+    if (
+      lowerMsg.includes('auth') ||
+      lowerMsg.includes('401') ||
+      lowerMsg.includes('403')
+    ) {
+      return { type: 'auth', message: msg, retryable: false };
+    }
+    if (
+      lowerMsg.includes('network') ||
+      lowerMsg.includes('fetch') ||
+      lowerMsg.includes('econnrefused') ||
+      lowerMsg.includes('econnreset')
+    ) {
+      return { type: 'network', message: msg, retryable: true };
+    }
+    return { type: 'api', message: msg, retryable: true };
+  }, [error]);
+
+  const handleRetry = useCallback(() => {
+    clearError();
+    const lastUserMessage = [...messages].reverse().find((m) => m.role === 'user');
+    if (!lastUserMessage) return;
+
+    const text = lastUserMessage.parts
+      ?.filter((p): p is { type: 'text'; text: string } => p.type === 'text')
+      .map((p) => p.text)
+      .join('');
+
+    if (text) {
+      resetStreamEvents();
+      sendMessage({ text });
+    }
+  }, [messages, clearError, sendMessage, resetStreamEvents]);
+
+  const handleDismissError = useCallback(() => {
+    clearError();
+  }, [clearError]);
+
+  // --------------- Permission handling ---------------
+  const handlePermissionDecision = useCallback(
+    async (result: PermissionDecisionResult) => {
+      if (!sessionId) return;
+      resolvePermission(result.requestId);
+
+      try {
+        await fetch(`${API_BASE}/api/chat/permission`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            sessionId,
+            requestId: result.requestId,
+            decision: result.decision,
+            scope: result.scope,
+          } satisfies PermissionResponse),
+        });
+      } catch (err) {
+        console.error('[permission] Failed to send decision:', err);
+      }
+    },
+    [sessionId, resolvePermission]
+  );
+
+  const pendingPermissionEntries = useMemo(
+    () => Array.from(pendingPermissions.values()),
+    [pendingPermissions]
+  );
+
+  // --------------- Plan handling ---------------
+  const buildPlanDraft = useCallback(
+    (heading: string) => {
+      if (!plan) return '';
+      return [
+        heading,
+        archivedPlanPath ? `Plan file: ${archivedPlanPath}` : undefined,
+        '',
+        plan.content,
+      ]
+        .filter((value): value is string => Boolean(value))
+        .join('\n');
+    },
+    [plan, archivedPlanPath]
+  );
+
+  const handlePlanApprove = useCallback(async () => {
+    if (!plan) return;
+    if (!sessionId) return;
+    approvePlan(plan.planId);
+
+    try {
+      await fetch(`${API_BASE}/api/chat/plan`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          sessionId,
+          planId: plan.planId,
+          decision: 'approve',
+        } satisfies PlanDecisionRequest),
+      });
+    } catch (err) {
+      console.error('[plan] Failed to send approval:', err);
+    }
+  }, [sessionId, plan, approvePlan]);
+
+  const handlePlanReject = useCallback(
+    async (feedback?: string) => {
+      if (!plan) return;
+      if (!sessionId) return;
+      rejectPlan(plan.planId, feedback);
+
+      try {
+        await fetch(`${API_BASE}/api/chat/plan`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            sessionId,
+            planId: plan.planId,
+            decision: 'reject',
+            feedback,
+          } satisfies PlanDecisionRequest),
+        });
+        if (feedback?.trim()) {
+          const prompt = getWorkflowPrompt(settings.workflowPrompts, 'reviewMemory');
+          promptMemoryUpdate({
+            trigger: 'review-feedback',
+            draft: {
+              fileName: 'MEMORY.md',
+              content: buildReviewMemoryDraft({ prompt, feedback }),
+            },
+            onOpenMemory: () => onOpenSettings?.('memory'),
+          });
+        }
+      } catch (err) {
+        console.error('[plan] Failed to send rejection:', err);
+      }
+    },
+    [sessionId, plan, rejectPlan, onOpenSettings, settings.workflowPrompts]
+  );
+
+  const handlePlanApproveWithFeedback = useCallback(
+    async (feedback?: string) => {
+      if (!plan) return;
+      if (!sessionId) return;
+      approvePlan(plan.planId);
+
+      try {
+        await fetch(`${API_BASE}/api/chat/plan`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            sessionId,
+            planId: plan.planId,
+            decision: 'approve',
+            feedback,
+          } satisfies PlanDecisionRequest),
+        });
+        if (feedback?.trim()) {
+          const prompt = getWorkflowPrompt(settings.workflowPrompts, 'reviewMemory');
+          promptMemoryUpdate({
+            trigger: 'review-feedback',
+            draft: {
+              fileName: 'MEMORY.md',
+              content: buildReviewMemoryDraft({ prompt, feedback }),
+            },
+            onOpenMemory: () => onOpenSettings?.('memory'),
+          });
+        }
+      } catch (err) {
+        console.error('[plan] Failed to send approval feedback:', err);
+      }
+    },
+    [sessionId, plan, approvePlan, onOpenSettings, settings.workflowPrompts]
+  );
+
+  const handlePlanInput = useCallback(
+    async (feedback: string) => {
+      const text = feedback.trim();
+      if (!text) return;
+
+      resetStreamEvents();
+      await sendMessage({
+        text: `Continue planning with this user input:\n${text}`,
+      } as any);
+    },
+    [resetStreamEvents, sendMessage]
+  );
+
+  const handlePlanCopy = useCallback(async () => {
+    const text = buildPlanDraft('Copy of current plan');
+    if (!text) return;
+    await navigator.clipboard.writeText(text);
+  }, [buildPlanDraft]);
+
+  const handlePlanExportToNewChat = useCallback(async () => {
+    const draft = buildPlanDraft('Implement this approved plan');
+    if (!draft) return;
+
+    window.sessionStorage.setItem(PLAN_EXPORT_DRAFT_KEY, draft);
+    if (onCreateSession) {
+      await onCreateSession();
+      return;
+    }
+
+    setInput(draft);
+  }, [buildPlanDraft, onCreateSession, setInput]);
+
+  const handlePlanHandoff = useCallback(async () => {
+    const text = buildPlanDraft('Handoff to another agent');
+    if (!text) return;
+    await navigator.clipboard.writeText(text);
+  }, [buildPlanDraft]);
+
+  // Archive plan effect
+  useEffect(() => {
+    if (!plan || !sessionId) return;
+    if (!plan.content.trim()) return;
+    if (plan.planId === archivedPlanId) return;
+    if (plan.status !== 'review' && plan.status !== 'approved' && plan.status !== 'rejected') {
+      return;
+    }
+
+    let cancelled = false;
+
+    void fetch(`${API_BASE}/api/chat/plan/archive`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sessionId,
+        planId: plan.planId,
+        content: plan.content,
+      }),
+    })
+      .then(async (response) => {
+        if (!response.ok) return null;
+        return (await response.json()) as { path?: string };
+      })
+      .then((result) => {
+        if (cancelled || !result?.path) return;
+        setArchivedPlanId(plan.planId);
+        setArchivedPlanPath(result.path);
+      })
+      .catch((archiveError) => {
+        console.error('[plan] Failed to archive plan:', archiveError);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [plan, sessionId, archivedPlanId, setArchivedPlanId, setArchivedPlanPath]);
+
+  // Restore plan export draft
+  useEffect(() => {
+    const draft = window.sessionStorage.getItem(PLAN_EXPORT_DRAFT_KEY);
+    if (!draft) return;
+    if (input.trim().length > 0) return;
+
+    setInput(draft);
+    window.sessionStorage.removeItem(PLAN_EXPORT_DRAFT_KEY);
+  }, [sessionId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // --------------- Fix errors handler ---------------
+  const handleFixErrors = useCallback(
+    async (toolCall: ToolCallState) => {
+      if (!toolCall.ciFailures) return;
+
+      const command = extractCommandFromToolInput(toolCall.input);
+      const checks =
+        toolCall.ciFailures.checks.length > 0
+          ? `\nFailing checks:\n${toolCall.ciFailures.checks
+              .map((item) => `- ${item}`)
+              .join('\n')}`
+          : '';
+      const commandLine = command ? `\nLast command: ${command}` : '';
+      const prompt = `The previous CI checks failed. Please fix the issues and rerun validation.${checks}${commandLine}\n\nRaw logs:\n${toolCall.ciFailures.rawOutput}`;
+
+      resetStreamEvents();
+      setInput('');
+      await sendMessage({ text: prompt });
+    },
+    [isLoading, resetStreamEvents, sendMessage, setInput]
+  );
+
+  // --------------- Rewind handlers ---------------
+  const handleRewindClick = useCallback(
+    async (checkpointId: string) => {
+      const cp = checkpoints.find((c) => c.id === checkpointId);
+      if (!cp) return;
+      setRewindTarget(cp);
+      setIsLoadingPreview(true);
+      const preview = await previewRewind(checkpointId);
+      setRewindPreview(preview);
+      setIsLoadingPreview(false);
+    },
+    [checkpoints, previewRewind, setRewindTarget, setIsLoadingPreview, setRewindPreview]
+  );
+
+  const handleRewindConfirm = useCallback(
+    async (mode: RewindMode) => {
+      if (!rewindTarget) return;
+      const ok = await executeRewind(rewindTarget.id, mode);
+      if (ok && sessionId) {
+        try {
+          const res = await fetch(`${API_BASE}/api/sessions/${sessionId}/messages`);
+          if (res.ok) {
+            const saved: Message[] = await res.json();
+            setMessages(saved.map(toUIMessage));
+          }
+        } catch {
+          // ignore
+        }
+
+        if (workspaceId) {
+          void fetchWorkspaceDiff();
+        }
+      }
+      setRewindTarget(null);
+      setRewindPreview(null);
+    },
+    [rewindTarget, executeRewind, sessionId, setMessages, workspaceId, fetchWorkspaceDiff, setRewindTarget, setRewindPreview]
+  );
+
+  const handleRewindCancel = useCallback(() => {
+    setRewindTarget(null);
+    setRewindPreview(null);
+  }, [setRewindTarget, setRewindPreview]);
+
+  const handleViewLatestChanges = useCallback(
+    async (range: { fromRef: string; toRef: string }) => {
+      if (!workspaceId) return;
+      setLatestChangesOpen(true);
+      setLatestChangesLoading(true);
+      setLatestChangesError(null);
+      try {
+        const result = await workspaceApi.fetchWorkspaceDiff(workspaceId, range);
+        setLatestChangesDiff(result.diff);
+      } catch (err) {
+        setLatestChangesError(err instanceof Error ? err.message : 'Failed to load diff');
+        setLatestChangesDiff('');
+      } finally {
+        setLatestChangesLoading(false);
+      }
+    },
+    [workspaceId, setLatestChangesOpen, setLatestChangesLoading, setLatestChangesError, setLatestChangesDiff]
+  );
+
+  // --------------- Suggestion handlers ---------------
+  const handleAcceptGhostText = useCallback(() => {
+    if (currentSuggestion) {
+      acceptSuggestion(currentSuggestion);
+    }
+  }, [currentSuggestion, acceptSuggestion]);
+
+  const handleSuggestionChipSelect = useCallback(
+    (suggestion: string) => {
+      setInput(suggestion);
+    },
+    [setInput]
+  );
+
+  // --------------- Compose prompt with attachments ---------------
+  const composePromptWithAttachments = useCallback(
+    (text: string, files: AttachedImage[]) => {
+      if (!files.length) return text;
+
+      const mentioned = new Set((text.match(/@([^\s]+)/g) || []).map((match) => match.slice(1)));
+      const additional = files.filter(
+        (file) =>
+          !mentioned.has(file.name) &&
+          !mentioned.has(file.name.split('/').pop() || '')
+      );
+      if (!additional.length) return text;
+
+      const lines = additional.map((file) => `- @${file.name}`);
+      return `${text}\n\nAttached files:\n${lines.join('\n')}`;
+    },
+    []
+  );
+
+  // --------------- Submit handler ---------------
+  const handleSubmit = useCallback(async () => {
+    const text = input.trim();
+    if (!text || isLoading) return;
+
+    if (text.startsWith('/')) {
+      const commandToken = text.slice(1).trim().split(/\s+/)[0]?.toLowerCase() ?? '';
+      if (commandToken) {
+        const matchedCommand = commands.find(
+          (cmd) => cmd.name.toLowerCase() === commandToken
+        );
+        if (matchedCommand) {
+          const commandArgs = text.slice(commandToken.length + 1).trim();
+          setInput('');
+          if (commandToken === 'add-dir' && onOpenWorkspacePaths) {
+            onOpenWorkspacePaths(commandArgs || undefined);
+            return;
+          }
+          if (commandToken === 'browser') {
+            resetStreamEvents();
+            await runBrowserWorkflow(commandArgs);
+            return;
+          }
+          handleCommandSelect(matchedCommand);
+          return;
+        }
+
+        const pluginCommands = new Set(
+          (sessionInfo?.slashCommands ?? []).map((command: string) => command.toLowerCase())
+        );
+        if (!pluginCommands.has(commandToken)) {
+          setMessages((prev: UIMessage[]) => [
+            ...prev,
+            {
+              id: `invalid-slash-${Date.now()}`,
+              role: 'assistant',
+              parts: [
+                {
+                  type: 'text',
+                  text: `Invalid slash command: /${commandToken}`,
+                },
+              ],
+            } as UIMessage,
+          ]);
+          return;
+        }
+      }
+    }
+
+    const payload = composePromptWithAttachments(text, attachments);
+    lastUserPromptRef.current = text;
+    lastUserMessageIdRef.current = `user-${Date.now()}`;
+
+    setInput('');
+    resetStreamEvents();
+    setAttachments([]);
+    await sendMessage({ text: payload });
+  }, [
+    input,
+    isLoading,
+    commands,
+    setInput,
+    onOpenWorkspacePaths,
+    resetStreamEvents,
+    runBrowserWorkflow,
+    handleCommandSelect,
+    sessionInfo,
+    setMessages,
+    composePromptWithAttachments,
+    attachments,
+    lastUserPromptRef,
+    lastUserMessageIdRef,
+    setAttachments,
+    sendMessage,
+  ]);
+
+  return {
+    // Command palette
+    commands,
+    paletteOpen,
+    paletteFilter,
+    filteredCommands,
+    handleInputChange,
+    handleCommandSelectAndClear,
+    handlePaletteClose,
+    handleCommandSelect,
+
+    // Shortcuts
+    shortcuts,
+
+    // Error
+    chatError,
+    handleRetry,
+    handleDismissError,
+
+    // Permission
+    handlePermissionDecision,
+    pendingPermissionEntries,
+
+    // Plan
+    handlePlanApprove,
+    handlePlanReject,
+    handlePlanApproveWithFeedback,
+    handlePlanInput,
+    handlePlanCopy,
+    handlePlanExportToNewChat,
+    handlePlanHandoff,
+
+    // Fix errors
+    handleFixErrors,
+
+    // Rewind
+    handleRewindClick,
+    handleRewindConfirm,
+    handleRewindCancel,
+
+    // Latest changes
+    handleViewLatestChanges,
+
+    // Suggestions
+    handleAcceptGhostText,
+    handleSuggestionChipSelect,
+
+    // Thinking
+    toggleThinkingVisibility,
+    toggleThinkingExpanded,
+
+    // Workflows
+    runReviewWorkflow,
+    runPrWorkflow,
+    runBranchWorkflow,
+    runBrowserWorkflow,
+
+    // Dashboard
+    handleDashboardModalConfirm,
+    generateDashboard,
+
+    // Clear
+    clearChat,
+
+    // Submit
+    handleSubmit,
+  };
+}

--- a/apps/desktop/src/components/chat/chatPageTypes.ts
+++ b/apps/desktop/src/components/chat/chatPageTypes.ts
@@ -1,0 +1,97 @@
+import type { UIMessage } from '@ai-sdk/react';
+import type { Message } from '@claude-tauri/shared';
+import type { CreateWorkspaceRequest } from '@claude-tauri/shared';
+import type { ToolCallState } from '@/hooks/useStreamEvents';
+
+export const API_BASE = 'http://localhost:3131';
+export const PLAN_EXPORT_DRAFT_KEY = 'claude-tauri-plan-export-draft';
+export const MAX_CONTEXT_TOKENS = 200_000;
+
+export interface ChatPageStatusData {
+  model: string | null;
+  isStreaming: boolean;
+  toolCalls: Map<string, ToolCallState>;
+  cumulativeUsage: import('@/hooks/useStreamEvents').CumulativeUsage;
+  sessionTotalCost: number;
+  subagentActiveCount: number;
+  checkpoints: import('@claude-tauri/shared').Checkpoint[];
+  sessionInfo?: {
+    sessionId: string;
+    model: string;
+    tools: string[];
+    mcpServers: Array<{ name: string; status: string }>;
+    claudeCodeVersion: string;
+  } | null;
+}
+
+export type LinearIssueContext = NonNullable<CreateWorkspaceRequest['linearIssue']>;
+
+export interface ChatPageProps {
+  sessionId: string | null;
+  onCreateSession?: () => void | Promise<void>;
+  onExportSession?: () => void | Promise<void>;
+  onStatusChange?: (data: ChatPageStatusData) => void;
+  onAutoName?: (sessionId: string) => void;
+  workspaceId?: string;
+  projectId?: string;
+  additionalDirectories?: string[];
+  onToggleSidebar?: () => void;
+  onOpenSettings?: (tab?: string) => void;
+  onOpenSessions?: () => void;
+  onOpenPullRequests?: () => void;
+  onOpenWorkspacePaths?: (path?: string) => void;
+  /** Called when a root-level agent task reaches a terminal status */
+  onTaskComplete?: (params: {
+    status: 'completed' | 'failed' | 'stopped';
+    summary: string;
+  }) => void;
+  /** Agent profile ID to use for this chat */
+  profileId?: string | null;
+  /** Available agent profiles for selection */
+  agentProfiles?: import('@claude-tauri/shared').AgentProfile[];
+  /** Callback when user selects a different profile */
+  onSelectProfile?: (id: string | null) => void;
+  /** Initial message to auto-send when the page mounts */
+  initialMessage?: string | null;
+  /** Called after the initial message has been consumed */
+  onInitialMessageConsumed?: () => void;
+  /** Called when backend initializes the app session ID */
+  onSessionInitialized?: (sessionId: string) => void;
+}
+
+export function extractCommandFromToolInput(input: string): string | undefined {
+  if (!input) return undefined;
+
+  try {
+    const parsed = JSON.parse(input);
+    if (typeof parsed === 'string') return parsed;
+    if (typeof parsed.command === 'string') return parsed.command;
+    if (Array.isArray(parsed.command)) return parsed.command.join(' ');
+  } catch {
+    return input;
+  }
+
+  return undefined;
+}
+
+/**
+ * Convert a persisted Message (from the DB) into a UIMessage
+ * that the AI SDK useChat hook understands.
+ */
+export function toUIMessage(msg: Message): UIMessage {
+  return {
+    id: msg.id,
+    role: msg.role,
+    parts: [{ type: 'text' as const, text: msg.content }],
+  };
+}
+
+export function getLatestAssistantMessageId(messages: UIMessage[]): string | null {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (messages[index].role === 'assistant') {
+      return messages[index].id;
+    }
+  }
+
+  return null;
+}

--- a/apps/desktop/src/components/chat/useChatPageState.ts
+++ b/apps/desktop/src/components/chat/useChatPageState.ts
@@ -1,0 +1,566 @@
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { useChat } from '@ai-sdk/react';
+import { DefaultChatTransport } from 'ai';
+import type { Message } from '@claude-tauri/shared';
+import { pickProviderConfig } from '@claude-tauri/shared';
+import type { AssistantResponseMetadata } from './MessageList';
+import { useStreamEvents } from '@/hooks/useStreamEvents';
+import type { UsageState } from '@/hooks/useStreamEvents';
+import { useSubagents } from '@/hooks/useSubagents';
+import { useCostTracking } from '@/hooks/useCostTracking';
+import { useSuggestions } from '@/hooks/useSuggestions';
+import { useContextSummary } from '@/hooks/useContextSummary';
+import { useMcpServers } from '@/hooks/useMcpServers';
+import { useCheckpoints } from '@/hooks/useCheckpoints';
+import { useSettings } from '@/hooks/useSettings';
+import { useWorkspaceDiff } from '@/hooks/useWorkspaceDiff';
+import { calculateCost, getModelFromName } from '@/lib/pricing';
+import type { AttachedImage } from './ChatInput';
+import type { ContextUsage } from './ContextIndicator';
+import type { Checkpoint, RewindPreview } from '@claude-tauri/shared';
+import * as linearApi from '@/lib/linear-api';
+import {
+  API_BASE,
+  MAX_CONTEXT_TOKENS,
+  type ChatPageProps,
+  type LinearIssueContext,
+  toUIMessage,
+  getLatestAssistantMessageId,
+} from './chatPageTypes';
+
+export function useChatPageState(props: ChatPageProps) {
+  const {
+    sessionId,
+    onStatusChange,
+    onAutoName,
+    workspaceId,
+    additionalDirectories,
+    onTaskComplete,
+    profileId,
+    initialMessage,
+    onInitialMessageConsumed,
+    onSessionInitialized,
+  } = props;
+
+  const { settings, updateSettings } = useSettings();
+
+  // --------------- Basic UI state ---------------
+  const [input, setInput] = useState('');
+  const [attachments, setAttachments] = useState<AttachedImage[]>([]);
+  const [linearIssue, setLinearIssue] = useState<LinearIssueContext | null>(null);
+  const [linearPickerOpen, setLinearPickerOpen] = useState(false);
+  const [helpOpen, setHelpOpen] = useState(false);
+  const [costOpen, setCostOpen] = useState(false);
+  const [thinkingExpanded, setThinkingExpanded] = useState(false);
+  const [thinkingToggleVersion, setThinkingToggleVersion] = useState(0);
+  const [dashboardModalOpen, setDashboardModalOpen] = useState(false);
+  const [dashboardModalLoading, setDashboardModalLoading] = useState(false);
+  const [dashboardModalError, setDashboardModalError] = useState<string | null>(null);
+
+  // --------------- Stream events hook ---------------
+  const {
+    toolCalls,
+    thinkingBlocks,
+    pendingPermissions,
+    resolvePermission,
+    plan,
+    approvePlan,
+    rejectPlan,
+    cumulativeUsage,
+    isCompacting,
+    usage,
+    sessionInfo,
+    processEvent,
+    reset: resetStreamEvents,
+  } = useStreamEvents();
+
+  // --------------- Subagents ---------------
+  const {
+    agents: subagents,
+    activeCount: subagentActiveCount,
+    isVisible: subagentPanelVisible,
+    toggleVisibility: toggleSubagentPanel,
+    reset: resetSubagents,
+  } = useSubagents({ onRootTaskComplete: onTaskComplete });
+
+  // --------------- Cost tracking ---------------
+  const {
+    messageCosts,
+    sessionTotalCost,
+    addMessageCost,
+    reset: resetCostTracking,
+  } = useCostTracking();
+
+  // --------------- Workspace diff ---------------
+  const {
+    diff: workspaceDiff,
+    changedFiles,
+    fetchDiff: fetchWorkspaceDiff,
+  } = useWorkspaceDiff(workspaceId ?? null);
+
+  const suggestedFiles = useMemo(
+    () => changedFiles.map((file) => file.path),
+    [changedFiles]
+  );
+
+  useEffect(() => {
+    if (!workspaceId) return;
+    void fetchWorkspaceDiff();
+  }, [workspaceId, fetchWorkspaceDiff]);
+
+  // --------------- Checkpoint / rewind state ---------------
+  const lastUserPromptRef = useRef('');
+  const lastUserMessageIdRef = useRef('');
+  const initialMessageSentRef = useRef(false);
+  const [rewindTarget, setRewindTarget] = useState<Checkpoint | null>(null);
+  const [rewindPreview, setRewindPreview] = useState<RewindPreview | null>(null);
+  const [isLoadingPreview, setIsLoadingPreview] = useState(false);
+  const [latestChangesOpen, setLatestChangesOpen] = useState(false);
+  const [latestChangesLoading, setLatestChangesLoading] = useState(false);
+  const [latestChangesDiff, setLatestChangesDiff] = useState('');
+  const [latestChangesError, setLatestChangesError] = useState<string | null>(null);
+  const [archivedPlanId, setArchivedPlanId] = useState<string | null>(null);
+  const [archivedPlanPath, setArchivedPlanPath] = useState<string | null>(null);
+  const [assistantMetadata, setAssistantMetadata] = useState<
+    Record<string, AssistantResponseMetadata>
+  >({});
+
+  // --------------- Auto-naming ---------------
+  const userMsgCountRef = useRef(0);
+  const autoNameCalledRef = useRef(false);
+  const prevSessionIdRef = useRef(sessionId);
+
+  if (sessionId !== prevSessionIdRef.current) {
+    prevSessionIdRef.current = sessionId;
+    userMsgCountRef.current = 0;
+    autoNameCalledRef.current = false;
+  }
+
+  // --------------- Context usage ---------------
+  const contextUsage: ContextUsage = useMemo(
+    () => ({
+      inputTokens: cumulativeUsage.inputTokens,
+      outputTokens: cumulativeUsage.outputTokens,
+      cacheReadTokens: cumulativeUsage.cacheReadTokens,
+      cacheCreationTokens: cumulativeUsage.cacheCreationTokens,
+      maxTokens: MAX_CONTEXT_TOKENS,
+    }),
+    [cumulativeUsage]
+  );
+
+  const lastRecordedUsageRef = useRef<UsageState | null>(null);
+
+  // --------------- Transport ---------------
+  const transport = useMemo(
+    () =>
+      new DefaultChatTransport({
+        api: `${API_BASE}/api/chat`,
+        body: {
+          sessionId,
+          model: settings.model,
+          effort: settings.fastMode ? 'low' : settings.effort,
+          thinkingBudgetTokens: settings.thinkingBudgetTokens,
+          permissionMode: settings.permissionMode,
+          provider: settings.provider,
+          runtimeEnv: settings.runtimeEnv,
+          systemPrompt: settings.systemPrompt || undefined,
+          providerConfig: pickProviderConfig(settings.provider, settings),
+          ...(workspaceId ? { workspaceId } : {}),
+          ...(additionalDirectories && additionalDirectories.length > 0
+            ? { additionalDirectories }
+            : {}),
+          ...(linearIssue ? { linearIssue } : {}),
+          ...(profileId ? { profileId } : {}),
+        },
+      }),
+    [
+      sessionId,
+      settings.model,
+      settings.effort,
+      settings.fastMode,
+      settings.thinkingBudgetTokens,
+      settings.permissionMode,
+      settings.provider,
+      settings.runtimeEnv,
+      settings.systemPrompt,
+      settings.bedrockBaseUrl,
+      settings.bedrockProjectId,
+      settings.vertexProjectId,
+      settings.vertexBaseUrl,
+      settings.customBaseUrl,
+      workspaceId,
+      additionalDirectories,
+      linearIssue,
+      profileId,
+    ]
+  );
+
+  // --------------- Deep-link: #linear/issue/ENG-123 ---------------
+  useEffect(() => {
+    const match = window.location.hash.match(/^#linear\/issue\/([^/?#]+)$/);
+    if (!match?.[1]) return;
+    const identifier = decodeURIComponent(match[1]);
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const issue = await linearApi.getIssue(identifier);
+        if (cancelled) return;
+        setLinearIssue({
+          id: issue.id,
+          title: issue.title,
+          summary: issue.summary,
+          url: issue.url,
+        });
+      } catch {
+        // ignore
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // --------------- Chat hook ---------------
+  const [chatId] = useState<string>(
+    () =>
+      sessionId ??
+      (typeof crypto !== 'undefined' && crypto.randomUUID
+        ? crypto.randomUUID()
+        : `fallback-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  );
+
+  const handleDataPart = useCallback(
+    (part: { type: string; data?: unknown }) => {
+      if (
+        part.type === 'data-stream-event' &&
+        part.data &&
+        typeof part.data === 'object' &&
+        'type' in part.data
+      ) {
+        if ((part.data as { type: string }).type === 'session:init') {
+          const event = part.data as { type: 'session:init'; sessionId?: string };
+          if (typeof event.sessionId === 'string' && event.sessionId.trim().length > 0) {
+            onSessionInitialized?.(event.sessionId);
+          }
+        }
+        processEvent(part.data as import('@claude-tauri/shared').StreamEvent);
+      }
+    },
+    [processEvent, onSessionInitialized]
+  );
+
+  const { messages, sendMessage, status, setMessages, error, clearError } = useChat({
+    id: chatId,
+    transport,
+    onData: handleDataPart as any,
+  });
+
+  const isLoading = status === 'submitted' || status === 'streaming';
+
+  // --------------- Record cost when usage arrives ---------------
+  useEffect(() => {
+    if (usage && usage !== lastRecordedUsageRef.current) {
+      lastRecordedUsageRef.current = usage;
+      const model = sessionInfo?.model ?? 'claude-sonnet-4';
+      const latestAssistantId = getLatestAssistantMessageId(messages);
+      const costUsd =
+        usage.costUsd > 0
+          ? usage.costUsd
+          : calculateCost(
+              {
+                inputTokens: usage.inputTokens,
+                outputTokens: usage.outputTokens,
+                cacheReadTokens: usage.cacheReadTokens,
+                cacheCreationTokens: usage.cacheCreationTokens,
+              },
+              getModelFromName(model)
+            );
+
+      addMessageCost({
+        messageId: `turn-${Date.now()}`,
+        model,
+        inputTokens: usage.inputTokens,
+        outputTokens: usage.outputTokens,
+        cacheReadTokens: usage.cacheReadTokens,
+        cacheCreationTokens: usage.cacheCreationTokens,
+        costUsd,
+        durationMs: usage.durationMs,
+      });
+
+      if (latestAssistantId) {
+        setAssistantMetadata((current) => ({
+          ...current,
+          [latestAssistantId]: {
+            changedFiles: current[latestAssistantId]?.changedFiles ?? [],
+            model,
+            durationMs: usage.durationMs,
+            inputTokens: usage.inputTokens,
+            outputTokens: usage.outputTokens,
+            cacheReadTokens: usage.cacheReadTokens,
+            cacheCreationTokens: usage.cacheCreationTokens,
+          },
+        }));
+      }
+    }
+  }, [usage, sessionInfo, addMessageCost, messages]);
+
+  // --------------- Checkpoints ---------------
+  const {
+    checkpoints,
+    previewRewind,
+    executeRewind,
+    reset: resetCheckpoints,
+  } = useCheckpoints({
+    sessionId,
+    toolCalls,
+    lastUserPrompt: lastUserPromptRef.current,
+    userMessageId: lastUserMessageIdRef.current,
+    isStreaming: isLoading,
+  });
+
+  // --------------- Suggestions ---------------
+  const handleSuggestionAccept = useCallback((suggestion: string) => {
+    setInput(suggestion);
+  }, []);
+
+  const {
+    suggestions,
+    currentSuggestion,
+    accept: acceptSuggestion,
+    dismiss: dismissSuggestion,
+    dismissAll: dismissAllSuggestions,
+  } = useSuggestions(messages, { onAccept: handleSuggestionAccept });
+
+  const { summary: contextSummary } = useContextSummary(sessionId, messages, isLoading);
+  const { visibleEnabledServers: mcpServers } = useMcpServers();
+
+  // --------------- Load persisted messages when session changes ---------------
+  useEffect(() => {
+    if (!sessionId) {
+      setMessages([]);
+      setAssistantMetadata({});
+      return;
+    }
+
+    setMessages([]);
+    setAssistantMetadata({});
+
+    let cancelled = false;
+
+    async function loadMessages() {
+      try {
+        const res = await fetch(`${API_BASE}/api/sessions/${sessionId}/messages`);
+        if (!res.ok) return;
+
+        const saved: Message[] = await res.json();
+        if (cancelled) return;
+
+        setMessages(saved.map(toUIMessage));
+      } catch {
+        // Server not reachable
+      }
+    }
+
+    loadMessages();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, setMessages]);
+
+  // --------------- Auto-name after first streaming completes ---------------
+  const wasStreamingRef = useRef(false);
+  useEffect(() => {
+    if (isLoading) {
+      wasStreamingRef.current = true;
+    } else if (wasStreamingRef.current) {
+      wasStreamingRef.current = false;
+      const completedAssistantId = getLatestAssistantMessageId(messages);
+      if (workspaceId && completedAssistantId) {
+        void fetchWorkspaceDiff().then((latest) => {
+          const changedFilesForTurn =
+            latest?.changedFiles?.map((file) => file.path) ?? [];
+          setAssistantMetadata((current) => {
+            const existing = current[completedAssistantId];
+            if (!existing) return current;
+
+            return {
+              ...current,
+              [completedAssistantId]: {
+                ...existing,
+                changedFiles: changedFilesForTurn,
+              },
+            };
+          });
+        });
+      }
+
+      userMsgCountRef.current += 1;
+      if (
+        userMsgCountRef.current >= 1 &&
+        !autoNameCalledRef.current &&
+        sessionId &&
+        onAutoName
+      ) {
+        autoNameCalledRef.current = true;
+        onAutoName(sessionId);
+      }
+    }
+  }, [isLoading, sessionId, onAutoName, messages, workspaceId, fetchWorkspaceDiff]);
+
+  // --------------- Report status to parent ---------------
+  useEffect(() => {
+    onStatusChange?.({
+      model: sessionInfo?.model ?? null,
+      isStreaming: isLoading,
+      toolCalls,
+      cumulativeUsage,
+      sessionTotalCost,
+      subagentActiveCount,
+      checkpoints,
+      sessionInfo: sessionInfo ?? null,
+    });
+  }, [
+    sessionInfo,
+    isLoading,
+    toolCalls,
+    cumulativeUsage,
+    sessionTotalCost,
+    subagentActiveCount,
+    checkpoints,
+    onStatusChange,
+  ]);
+
+  // --------------- Auto-send initial message ---------------
+  useEffect(() => {
+    if (!initialMessage) {
+      initialMessageSentRef.current = false;
+      return;
+    }
+
+    if (initialMessageSentRef.current) {
+      return;
+    }
+
+    initialMessageSentRef.current = true;
+    onInitialMessageConsumed?.();
+    resetStreamEvents();
+    lastUserPromptRef.current = initialMessage;
+    lastUserMessageIdRef.current = `user-${Date.now()}`;
+    void sendMessage({ text: initialMessage } as any);
+  }, [initialMessage, onInitialMessageConsumed, resetStreamEvents, sendMessage]);
+
+  return {
+    // Settings
+    settings,
+    updateSettings,
+
+    // Basic UI state
+    input,
+    setInput,
+    attachments,
+    setAttachments,
+    linearIssue,
+    setLinearIssue,
+    linearPickerOpen,
+    setLinearPickerOpen,
+    helpOpen,
+    setHelpOpen,
+    costOpen,
+    setCostOpen,
+    thinkingExpanded,
+    setThinkingExpanded,
+    thinkingToggleVersion,
+    setThinkingToggleVersion,
+    dashboardModalOpen,
+    setDashboardModalOpen,
+    dashboardModalLoading,
+    setDashboardModalLoading,
+    dashboardModalError,
+    setDashboardModalError,
+
+    // Stream events
+    toolCalls,
+    thinkingBlocks,
+    pendingPermissions,
+    resolvePermission,
+    plan,
+    approvePlan,
+    rejectPlan,
+    cumulativeUsage,
+    isCompacting,
+    usage,
+    sessionInfo,
+    resetStreamEvents,
+
+    // Subagents
+    subagents,
+    subagentActiveCount,
+    subagentPanelVisible,
+    toggleSubagentPanel,
+    resetSubagents,
+
+    // Cost
+    messageCosts,
+    sessionTotalCost,
+    resetCostTracking,
+
+    // Workspace diff
+    workspaceDiff,
+    changedFiles,
+    fetchWorkspaceDiff,
+    suggestedFiles,
+
+    // Checkpoints / rewind
+    lastUserPromptRef,
+    lastUserMessageIdRef,
+    rewindTarget,
+    setRewindTarget,
+    rewindPreview,
+    setRewindPreview,
+    isLoadingPreview,
+    setIsLoadingPreview,
+    latestChangesOpen,
+    setLatestChangesOpen,
+    latestChangesLoading,
+    setLatestChangesLoading,
+    latestChangesDiff,
+    setLatestChangesDiff,
+    latestChangesError,
+    setLatestChangesError,
+    archivedPlanId,
+    setArchivedPlanId,
+    archivedPlanPath,
+    setArchivedPlanPath,
+    assistantMetadata,
+    setAssistantMetadata,
+    checkpoints,
+    previewRewind,
+    executeRewind,
+    resetCheckpoints,
+
+    // Context
+    contextUsage,
+    contextSummary,
+
+    // Chat hook
+    messages,
+    sendMessage,
+    isLoading,
+    setMessages,
+    error,
+    clearError,
+
+    // Suggestions
+    suggestions,
+    currentSuggestion,
+    acceptSuggestion,
+    dismissSuggestion,
+    dismissAllSuggestions,
+
+    // MCP servers
+    mcpServers,
+  };
+}


### PR DESCRIPTION
## Summary
Closes #273

Split ChatPage.tsx (1515 lines) into smaller, focused modules.

## Test plan
- [ ] Chat page renders and functions correctly
- [ ] Desktop tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)