### PR TITLE
fix(ux): F-153-001 — ChatPage crash on conversation open

### DIFF
--- a/apps/desktop/src/components/chat/ChatPage.tsx
+++ b/apps/desktop/src/components/chat/ChatPage.tsx
@@ -76,6 +76,7 @@ export function ChatPage(props: ChatPageProps) {
     suggestions,
     contextSummary,
     mcpServers,
+    sessionInfo,
   } = state;
 
   const {


### PR DESCRIPTION
## Summary
- **Root cause**: `sessionInfo` was used in `ChatPage.tsx` but never destructured from the `useChatPageState()` return value
- **Impact**: Clicking any conversation in the sidebar crashed the entire app with an ErrorBoundary error ("Something went wrong")
- **Fix**: Added `sessionInfo` to the destructuring block (1 line change)
- **Blocked**: ~50% of UX walker stories (30+ stories) were blocked by this single bug

## Test plan
- [ ] Click on an existing conversation in the sidebar — should load without crashing
- [ ] Open a workspace/project — should load without crashing
- [ ] Navigate between chat sessions — no ErrorBoundary errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)