### PR TITLE
fix(ux): STORY-086 — Linear deep link opens linear.app

### DIFF
--- a/apps/desktop/src/components/chat/LinearIssueBar.tsx
+++ b/apps/desktop/src/components/chat/LinearIssueBar.tsx
@@ -7,17 +7,31 @@ interface LinearIssueBarProps {
 }
 
 export function LinearIssueBar({ linearIssue, onOpenPicker, onClear }: LinearIssueBarProps) {
+  const handleOpenLinear = () => {
+    if (linearIssue.url) {
+      window.open(linearIssue.url, '_blank', 'noopener,noreferrer');
+    }
+  };
+
   return (
     <div className="border-t border-border px-4 py-2 flex items-center gap-2">
       <div className="text-xs text-muted-foreground shrink-0">Issue:</div>
       <button
         className="text-xs font-mono text-primary hover:underline underline-offset-2 truncate"
-        onClick={onOpenPicker}
-        title={linearIssue.title}
+        onClick={handleOpenLinear}
+        title={linearIssue.url ? `Open ${linearIssue.id} on Linear` : linearIssue.title}
+        aria-label={`Open issue ${linearIssue.id} on Linear`}
       >
         {linearIssue.id}
       </button>
-      <div className="text-xs text-muted-foreground truncate">{linearIssue.title}</div>
+      <button
+        className="text-xs text-muted-foreground truncate hover:text-foreground"
+        onClick={onOpenPicker}
+        title="Change linked issue"
+        aria-label="Change linked Linear issue"
+      >
+        {linearIssue.title}
+      </button>
       <button
         className="ml-auto rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-accent hover:text-foreground"
         onClick={onClear}


### PR DESCRIPTION
## Summary
- **STORY-086**: Clicking the Linear issue ID badge (e.g., "ENG-123") now opens the issue on `linear.app` in a new tab instead of opening the picker modal
- Issue title text is now clickable to open the picker (change linked issue)
- Added proper `aria-label` and `title` attributes for accessibility

## Interaction model
| Element | Click Action |
|---------|-------------|
| Issue ID badge (e.g., "ENG-123") | Opens issue on linear.app |
| Issue title text | Opens picker to change linked issue |
| "Clear" button | Removes linked issue (unchanged) |

## Test plan
- [ ] Click issue ID badge → opens linear.app URL in new tab
- [ ] Click issue title → opens picker modal
- [ ] Verify tooltip on issue ID says "Open ENG-123 on Linear"
- [ ] Clear button still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)