### PR TITLE
feat: GitHub issue body preview + search history (STORY-094, STORY-095)

### DIFF
--- a/apps/desktop/src/components/linear/LinearIssuePicker.tsx
+++ b/apps/desktop/src/components/linear/LinearIssuePicker.tsx
@@ -1,10 +1,12 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { X, ClockCounterClockwise } from '@phosphor-icons/react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { toast } from 'sonner';
 import type { Project } from '@claude-tauri/shared';
 import * as linear from '@/lib/linear-api';
 import * as workspaceApi from '@/lib/workspace-api';
+import { useSearchHistory } from '@/hooks/useSearchHistory';
 
 type LinearIssue = linear.LinearIssue;
 
@@ -29,6 +31,9 @@ export function LinearIssuePicker({
   const [issues, setIssues] = useState<LinearIssue[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [showHistory, setShowHistory] = useState(false);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const { history: searchHistory, addSearch, removeSearch, clearAll: clearHistory } = useSearchHistory('linear');
 
   const [selectedIssue, setSelectedIssue] = useState<LinearIssue | null>(null);
   const [projects, setProjects] = useState<Project[]>([]);
@@ -86,6 +91,7 @@ export function LinearIssuePicker({
           const list = await linear.listIssues(query);
           if (cancelled) return;
           setIssues(list);
+          if (query.trim()) addSearch(query.trim());
         } catch (err) {
           if (cancelled) return;
           setIssues([]);
@@ -202,16 +208,64 @@ export function LinearIssuePicker({
         ) : (
           <div className="grid grid-cols-2 gap-0">
             <div className="border-r border-border p-4">
+              <div className="relative">
               <div className="flex items-center gap-2">
                 <Input
+                  ref={searchInputRef}
                   value={query}
                   onChange={(e) => setQuery(e.target.value)}
+                  onFocus={() => setShowHistory(true)}
+                  onBlur={() => setTimeout(() => setShowHistory(false), 200)}
                   placeholder="Search by title or identifier (e.g. ENG-123)…"
                 />
                 <Button variant="outline" size="sm" onClick={() => setQuery('')}>
                   Clear
                 </Button>
               </div>
+              {showHistory && searchHistory.length > 0 && !query.trim() && (
+                <div className="absolute z-10 mt-1 w-full rounded-md border border-border bg-popover shadow-md">
+                  <div className="flex items-center justify-between px-3 py-1.5 border-b border-border">
+                    <span className="text-xs font-medium text-muted-foreground flex items-center gap-1">
+                      <ClockCounterClockwise className="h-3 w-3" />
+                      Recent searches
+                    </span>
+                    <button
+                      type="button"
+                      className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                      onMouseDown={(e) => e.preventDefault()}
+                      onClick={() => clearHistory()}
+                    >
+                      Clear all
+                    </button>
+                  </div>
+                  {searchHistory.map((item) => (
+                    <div
+                      key={item}
+                      className="flex items-center gap-2 px-3 py-1.5 hover:bg-accent cursor-pointer"
+                      onMouseDown={(e) => e.preventDefault()}
+                      onClick={() => {
+                        setQuery(item);
+                        setShowHistory(false);
+                      }}
+                    >
+                      <span className="text-sm truncate flex-1">{item}</span>
+                      <button
+                        type="button"
+                        className="p-0.5 text-muted-foreground hover:text-foreground transition-colors shrink-0"
+                        onMouseDown={(e) => e.preventDefault()}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          removeSearch(item);
+                        }}
+                        title="Remove from history"
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
               {error && (
                 <div className="mt-3 rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
                   {error}

--- a/apps/desktop/src/components/workspaces/CreateWorkspaceDialog.tsx
+++ b/apps/desktop/src/components/workspaces/CreateWorkspaceDialog.tsx
@@ -112,6 +112,9 @@ export function CreateWorkspaceDialog({
               onWorkspaceNameChange={state.setIssueWorkspaceName}
               issueBranch={state.issueBranch}
               onIssueBranchChange={state.setIssueBranch}
+              searchHistory={state.githubSearchHistory}
+              onRemoveHistory={state.removeGithubSearch}
+              onClearHistory={state.clearGithubSearchHistory}
             />
           )}
 

--- a/apps/desktop/src/components/workspaces/GithubIssueModeForm.tsx
+++ b/apps/desktop/src/components/workspaces/GithubIssueModeForm.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { SpinnerGap, CaretDown, CaretRight } from '@phosphor-icons/react';
+import { useState, useRef } from 'react';
+import { SpinnerGap, CaretDown, CaretRight, X, ClockCounterClockwise } from '@phosphor-icons/react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Input } from '@/components/ui/input';
@@ -17,6 +17,9 @@ interface GithubIssueModeFormProps {
   onWorkspaceNameChange: (value: string) => void;
   issueBranch: string;
   onIssueBranchChange: (value: string) => void;
+  searchHistory?: string[];
+  onRemoveHistory?: (query: string) => void;
+  onClearHistory?: () => void;
 }
 
 export function GithubIssueModeForm({
@@ -31,21 +34,82 @@ export function GithubIssueModeForm({
   onWorkspaceNameChange,
   issueBranch,
   onIssueBranchChange,
+  searchHistory = [],
+  onRemoveHistory,
+  onClearHistory,
 }: GithubIssueModeFormProps) {
   const [expandedIssue, setExpandedIssue] = useState<number | null>(null);
+  const [showHistory, setShowHistory] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const hasHistory = searchHistory.length > 0;
+  const shouldShowHistory = showHistory && hasHistory && !issueQuery.trim();
 
   return (
     <>
-      <div>
+      <div className="relative">
         <label className="text-sm font-medium text-foreground">Search Issues</label>
         <Input
+          ref={inputRef}
           type="text"
           placeholder="Search by title or number..."
           value={issueQuery}
           onChange={(e) => onIssueQueryChange(e.target.value)}
+          onFocus={() => setShowHistory(true)}
+          onBlur={() => {
+            // Delay to allow click on history items
+            setTimeout(() => setShowHistory(false), 200);
+          }}
           className="mt-1"
           autoFocus
         />
+        {shouldShowHistory && (
+          <div className="absolute z-10 mt-1 w-full rounded-md border border-border bg-popover shadow-md">
+            <div className="flex items-center justify-between px-3 py-1.5 border-b border-border">
+              <span className="text-xs font-medium text-muted-foreground flex items-center gap-1">
+                <ClockCounterClockwise className="h-3 w-3" />
+                Recent searches
+              </span>
+              {onClearHistory && (
+                <button
+                  type="button"
+                  className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => onClearHistory()}
+                >
+                  Clear all
+                </button>
+              )}
+            </div>
+            {searchHistory.map((item) => (
+              <div
+                key={item}
+                className="flex items-center gap-2 px-3 py-1.5 hover:bg-accent cursor-pointer"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => {
+                  onIssueQueryChange(item);
+                  setShowHistory(false);
+                }}
+              >
+                <span className="text-sm truncate flex-1">{item}</span>
+                {onRemoveHistory && (
+                  <button
+                    type="button"
+                    className="p-0.5 text-muted-foreground hover:text-foreground transition-colors shrink-0"
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onRemoveHistory(item);
+                    }}
+                    title="Remove from history"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
       </div>
       <div className="max-h-64 overflow-auto rounded-md border border-border">
         {issueLoading ? (

--- a/apps/desktop/src/components/workspaces/useCreateWorkspaceState.ts
+++ b/apps/desktop/src/components/workspaces/useCreateWorkspaceState.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import type { GithubIssue, GithubBranch } from '@/lib/workspace-api';
 import { fetchGithubIssues, fetchProjectBranches, fetchGitBranchesFromPath } from '@/lib/workspace-api';
+import { useSearchHistory } from '@/hooks/useSearchHistory';
 
 type Mode = 'manual' | 'branch' | 'github-issue';
 
@@ -45,6 +46,9 @@ export function useCreateWorkspaceState(
   const [selectedIssue, setSelectedIssue] = useState<GithubIssue | null>(null);
   const [issueWorkspaceName, setIssueWorkspaceName] = useState('');
   const [issueBranch, setIssueBranch] = useState('');
+
+  // Search history
+  const githubSearchHistory = useSearchHistory('github');
 
   // Shared
   const [error, setError] = useState<string | null>(null);
@@ -108,7 +112,12 @@ export function useCreateWorkspaceState(
       let cancelled = false;
       setIssueLoading(true); setIssueError(null);
       fetchGithubIssues(projectId, issueQuery)
-        .then((list) => { if (!cancelled) setIssues(list); })
+        .then((list) => {
+          if (!cancelled) {
+            setIssues(list);
+            if (issueQuery.trim()) githubSearchHistory.addSearch(issueQuery.trim());
+          }
+        })
         .catch((err) => { if (!cancelled) setIssueError(err instanceof Error ? err.message : 'Failed to load issues'); })
         .finally(() => { if (!cancelled) setIssueLoading(false); });
       return () => { cancelled = true; };
@@ -186,6 +195,10 @@ export function useCreateWorkspaceState(
     selectedIssue, setSelectedIssue,
     issueWorkspaceName, setIssueWorkspaceName,
     issueBranch, setIssueBranch,
+    // Search history
+    githubSearchHistory: githubSearchHistory.history,
+    removeGithubSearch: githubSearchHistory.removeSearch,
+    clearGithubSearchHistory: githubSearchHistory.clearAll,
     // Shared
     error, setError, submitting,
     handleClose, handleSubmit,

--- a/apps/desktop/src/hooks/useSearchHistory.ts
+++ b/apps/desktop/src/hooks/useSearchHistory.ts
@@ -1,0 +1,66 @@
+import { useState, useCallback, useEffect } from 'react';
+
+const MAX_HISTORY = 10;
+
+function getStorageKey(namespace: string): string {
+  return `issue-search-history:${namespace}`;
+}
+
+function loadHistory(namespace: string): string[] {
+  try {
+    const raw = localStorage.getItem(getStorageKey(namespace));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((s): s is string => typeof s === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveHistory(namespace: string, items: string[]): void {
+  try {
+    localStorage.setItem(getStorageKey(namespace), JSON.stringify(items));
+  } catch {
+    // localStorage may be full or unavailable
+  }
+}
+
+/**
+ * Hook to manage recent issue search history in localStorage.
+ * @param namespace - Key prefix to separate GitHub vs Linear history
+ */
+export function useSearchHistory(namespace: string) {
+  const [history, setHistory] = useState<string[]>(() => loadHistory(namespace));
+
+  // Sync if namespace changes
+  useEffect(() => {
+    setHistory(loadHistory(namespace));
+  }, [namespace]);
+
+  const addSearch = useCallback((query: string) => {
+    const trimmed = query.trim();
+    if (!trimmed) return;
+    setHistory((prev) => {
+      // Deduplicate case-insensitive
+      const filtered = prev.filter((s) => s.toLowerCase() !== trimmed.toLowerCase());
+      const next = [trimmed, ...filtered].slice(0, MAX_HISTORY);
+      saveHistory(namespace, next);
+      return next;
+    });
+  }, [namespace]);
+
+  const removeSearch = useCallback((query: string) => {
+    setHistory((prev) => {
+      const next = prev.filter((s) => s.toLowerCase() !== query.toLowerCase());
+      saveHistory(namespace, next);
+      return next;
+    });
+  }, [namespace]);
+
+  const clearAll = useCallback(() => {
+    setHistory([]);
+    saveHistory(namespace, []);
+  }, [namespace]);
+
+  return { history, addSearch, removeSearch, clearAll };
+}


### PR DESCRIPTION
## Summary
- **STORY-094**: Expandable markdown preview for GitHub issue bodies in the workspace creation dialog. Click the caret to see the full issue body rendered with markdown support.
- **STORY-095**: Recent search history for both GitHub and Linear issue pickers. Shows last 10 searches on focus, with individual removal and "Clear all" controls. Stored in localStorage, deduplicated case-insensitively.

**Skipped stories** (closed in Linear with rationale):
- STORY-092 (Multi-Issue Workspace) — Kanban tracker handles this better via its local issue model
- STORY-093 (Linear Status Sync) — Premature; status lives in tracker now
- STORY-096 (Offline Mode) — Will come free once tracker-Linear sync is built

## Test plan
- [ ] Open workspace creation dialog → GitHub issue mode → search for an issue → verify expandable body preview works
- [ ] Verify markdown renders correctly in the preview (headings, lists, code blocks)
- [ ] Search for several issues → close and reopen picker → verify recent searches appear on focus
- [ ] Clear individual search history items and "Clear all"
- [ ] Test Linear issue picker search history works the same way
- [ ] Verify no regressions in existing workspace creation flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)