### PR TITLE
Fix SettingsPanel Escape-key dismissal with regression test

### DIFF
--- a/apps/desktop/src/components/settings/SettingsPanel.test.tsx
+++ b/apps/desktop/src/components/settings/SettingsPanel.test.tsx
@@ -118,6 +118,14 @@ describe('SettingsPanel', () => {
     expect(defaultProps.onClose).toHaveBeenCalledOnce();
   });
 
+  test('calls onClose when Escape key is pressed', () => {
+    renderWithProvider(<SettingsPanel {...defaultProps} />);
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(defaultProps.onClose).toHaveBeenCalledOnce();
+  });
+
   // ─── Group navigation ───
 
   test('renders 5 group buttons in sidebar', () => {

--- a/apps/desktop/src/components/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/components/settings/SettingsPanel.tsx
@@ -145,6 +145,20 @@ export function SettingsPanel({ isOpen, onClose, sessionInfo, email, plan, initi
       }
     }
   }, [isOpen, initialTab]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
   const [showApiKey, setShowApiKey] = useState(false);
   const { settings, updateSettings } = useSettings();
 

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -351,3 +351,9 @@ Each entry follows this format:
 - **What:** Implemented full artifact pipeline: SQLite schema (artifacts, artifact_revisions, message_parts), backend CRUD/generate/regenerate/archive routes, frontend Dashboards tab in WorkspacePanel, `/dashboard` slash command, ArtifactBlock inline renderer.
 - **Why:** Enables workspace chat to generate persistent, revisioned dashboards that survive page reload.
 - **Result:** All phases complete, 57+ new tests passing. Dashboard generation confirmed working end-to-end via curl verification. All seven new artifact endpoints return correct responses and status codes.
+
+## 2026-04-04
+### Settings dialog Escape-key close regression
+- **What:** Added a regression test asserting that pressing `Escape` closes `SettingsPanel`, then fixed `SettingsPanel` by wiring a window `keydown` listener (active only while open) that calls `onClose()` when `Escape` is pressed.
+- **Why:** Manual UI test documentation flagged that Escape dismissal was inconsistent for dialogs; settings lacked any Escape handler, so keyboard-based dismissal did nothing.
+- **Result:** The new regression test fails on old behavior and passes after the fix; the settings panel now closes via Escape key as expected.


### PR DESCRIPTION
### Motivation
- The Settings panel did not close when pressing `Escape`, causing an accessibility and UX regression that needed a deterministic regression test and fix.

### Description
- Added a window `keydown` listener in `apps/desktop/src/components/settings/SettingsPanel.tsx` that calls `onClose()` when `Escape` is pressed and is only active while the panel is open. 
- Added a regression test `calls onClose when Escape key is pressed` in `apps/desktop/src/components/settings/SettingsPanel.test.tsx` to guard the behavior. 
- Recorded the change in `docs/logs/engineering-log.md` under the 2026-04-04 entry.

### Testing
- Ran `cd apps/desktop && pnpm vitest run src/components/settings/SettingsPanel.test.tsx`, and the new test failed on the old code (verifying the regression was real) and then passed after the fix. 
- Final automated run of the file reports `36 passed (36)` tests and the suite for that file succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d14ab1af848323b6dba37f13fa7bdb)