### PR TITLE
[codex] Fix copy timeout cleanup on unmount

### DIFF
--- a/apps/desktop/src/components/shared/CopyButton.test.tsx
+++ b/apps/desktop/src/components/shared/CopyButton.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CopyButton } from './CopyButton';
+
+describe('CopyButton', () => {
+  let writeTextMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    writeTextMock = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: writeTextMock,
+      },
+    });
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('clears a pending copied-state timeout when unmounted', async () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const { unmount } = render(<CopyButton text="hello world" variant="text" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Copy code' }));
+      await Promise.resolve();
+    });
+
+    expect(writeTextMock).toHaveBeenCalledWith('hello world');
+    unmount();
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/components/shared/CopyButton.tsx
+++ b/apps/desktop/src/components/shared/CopyButton.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, type MouseEvent } from 'react';
+import { useState, useCallback, useEffect, useRef, type MouseEvent } from 'react';
 import { Check, Copy } from '@phosphor-icons/react';
 
 interface CopyButtonProps {
@@ -26,6 +26,15 @@ export function CopyButton({
   className,
 }: CopyButtonProps) {
   const [copied, setCopied] = useState(false);
+  const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (resetTimeoutRef.current !== null) {
+        clearTimeout(resetTimeoutRef.current);
+      }
+    };
+  }, []);
 
   const handleCopy = useCallback(
     async (e?: MouseEvent) => {
@@ -33,7 +42,13 @@ export function CopyButton({
       try {
         await navigator.clipboard.writeText(text);
         setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
+        if (resetTimeoutRef.current !== null) {
+          clearTimeout(resetTimeoutRef.current);
+        }
+        resetTimeoutRef.current = setTimeout(() => {
+          setCopied(false);
+          resetTimeoutRef.current = null;
+        }, 2000);
       } catch {
         // Fallback for environments without clipboard API
       }

--- a/apps/desktop/src/components/workspaces/DiffToolbar.tsx
+++ b/apps/desktop/src/components/workspaces/DiffToolbar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import type { DiffMode } from './diff-parser';
 import type * as api from '@/lib/workspace-api';
@@ -49,12 +49,27 @@ export function DiffToolbar({
   rawDiff,
 }: DiffToolbarProps) {
   const [copied, setCopied] = useState(false);
+  const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (resetTimeoutRef.current !== null) {
+        clearTimeout(resetTimeoutRef.current);
+      }
+    };
+  }, []);
 
   const handleCopy = async () => {
     try {
       await navigator.clipboard.writeText(rawDiff);
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      if (resetTimeoutRef.current !== null) {
+        clearTimeout(resetTimeoutRef.current);
+      }
+      resetTimeoutRef.current = setTimeout(() => {
+        setCopied(false);
+        resetTimeoutRef.current = null;
+      }, 2000);
     } catch {
       // clipboard write failed silently
     }

--- a/apps/desktop/src/components/workspaces/__tests__/DiffToolbar.test.tsx
+++ b/apps/desktop/src/components/workspaces/__tests__/DiffToolbar.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DiffToolbar } from '../DiffToolbar';
+
+describe('DiffToolbar', () => {
+  let writeTextMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    writeTextMock = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: writeTextMock,
+      },
+    });
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('clears a pending copied-state timeout when unmounted', async () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const { unmount } = render(
+      <DiffToolbar
+        viewMode="unified"
+        setViewMode={vi.fn()}
+        hasRangeDiff={false}
+        changedFilesCount={1}
+        draftFromRef=""
+        setDraftFromRef={vi.fn()}
+        draftToRef=""
+        setDraftToRef={vi.fn()}
+        revisions={[]}
+        rangeError={null}
+        filterMode="all"
+        setFilterMode={vi.fn()}
+        isAllReviewed={false}
+        reviewLoading={false}
+        onRefresh={vi.fn()}
+        onApplyRange={vi.fn()}
+        onToggleAllReviewed={vi.fn()}
+        onReviewClick={vi.fn()}
+        onReviewContextMenu={vi.fn()}
+        rawDiff="diff --git a/file b/file"
+      />
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+      await Promise.resolve();
+    });
+
+    expect(writeTextMock).toHaveBeenCalledWith('diff --git a/file b/file');
+    unmount();
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- clear pending copy-feedback timers in `CopyButton` and `DiffToolbar` when components unmount
- replace any existing timeout before scheduling a new one so repeated copies do not leave stale timers behind
- add regression tests that failed before the fix and now cover both components

## Root Cause
Both components scheduled `setTimeout(() => setCopied(false), 2000)` without retaining the timer handle or clearing it during unmount. Navigating away before the timer fired allowed a state update attempt on an unmounted component.

## Validation
- `pnpm --filter @claude-tauri/desktop exec vitest run src/components/shared/CopyButton.test.tsx src/components/workspaces/__tests__/DiffToolbar.test.tsx`
- `pnpm --filter @claude-tauri/desktop exec vitest run src/components/workspaces/__tests__/WorkspaceDiffView.test.tsx src/components/chat/MarkdownRenderer.test.tsx src/components/chat/__tests__/BashDisplay.test.tsx`
- Browser smoke: app loaded successfully at the worktree dev URL with no runtime errors reported by `agent-browser errors`

## Baseline Issues Not Changed Here
- `pnpm --filter @claude-tauri/desktop exec tsc --noEmit` fails on pre-existing issues in `src/components/chat/WelcomeScreen.tsx` and an unused import in `src/components/chat/__tests__/FileOperations.test.tsx`
- a broader desktop-suite run surfaced an unrelated existing failure in `src/components/sessions/SessionSidebar.test.tsx`

Closes #536
